### PR TITLE
Fixing rebalancing issues caused by:

### DIFF
--- a/Voron/Trees/Page.cs
+++ b/Voron/Trees/Page.cs
@@ -220,6 +220,11 @@ namespace Voron.Trees
 
             key = key ?? new Slice(other);
 
+			if (other->KeySize == 0) // when copy first item from branch which is implicit ref
+			{
+				nodeSize += key.Size;
+			}
+
             Debug.Assert(IsBranch == false || index != 0 || key.Size == 0);// branch page's first item must be the implicit ref
 
 

--- a/Voron/Trees/TreeRebalancer.cs
+++ b/Voron/Trees/TreeRebalancer.cs
@@ -169,9 +169,11 @@ namespace Voron.Trees
 
                 var implicitLeftKey = GetActualKey(to, 0);
                 var leftPageNumber = to.GetNode(0)->PageNumber;
-                to.AddNode(1, implicitLeftKey, -1, leftPageNumber);
-                to.AddNode(0, Slice.BeforeAllKeys, -1, pageNum);
-            }
+
+				to.AddNode(1, implicitLeftKey, -1, leftPageNumber);
+				to.AddNode(0, Slice.BeforeAllKeys, -1, pageNum);
+				to.RemoveNode(1);
+			}
             else
             {
                 to.AddNode(to.LastSearchPosition, originalFromKeyStart, -1, pageNum);


### PR DESCRIPTION
1) missing old node remove when moving branch
2) does not taking into account that the first node of branch page can have empty key during node size calculation
