### PR TITLE
Fix API usage

### DIFF
--- a/Performance.Comparison/Other/LMDB/lmdb_perf_test.cpp
+++ b/Performance.Comparison/Other/LMDB/lmdb_perf_test.cpp
@@ -46,6 +46,9 @@ public:
   time_t Time; 
 };
 
+#define RND 0
+#define SEQ 1
+
 vector<ParallelTestData> SplitData(vector<TestData> data, int currentItemsPerTransaction, int currentNumberOfTransactions, int numberOfThreads) {
 
   vector<ParallelTestData> results;
@@ -154,16 +157,16 @@ MDB_env* StorageEnvironment(bool deleteOldData, MDB_dbi *pdbi){
 
   MDB_txn *txn;
   mdb_txn_begin(env, NULL, 0, &txn);
-  mdb_open(txn, NULL, 0, pdbi);
+  mdb_open(txn, NULL, MDB_INTEGERKEY, pdbi);
   mdb_txn_commit(txn);
   
   return env;
 }
 
-vector<PerformanceRecord> WriteInternal(vector<TestData>::iterator begin, int itemsPerTransaction, int numberOfTransactions, MDB_env* env, MDB_dbi dbi) {
+vector<PerformanceRecord> WriteInternal(vector<TestData>::iterator begin, int itemsPerTransaction, int numberOfTransactions, int seqrand, MDB_env* env, MDB_dbi dbi) {
   vector<PerformanceRecord> records;
   
-  int rc;
+  int rc, flag = 0;
 
   MDB_val key, data;
 
@@ -171,12 +174,16 @@ vector<PerformanceRecord> WriteInternal(vector<TestData>::iterator begin, int it
   MDB_cursor *cursor;
   char sval[87 * 1024];
   
+  if (seqrand == SEQ)
+  	flag = MDB_APPEND;
+
   for(int transactions = 0; transactions < numberOfTransactions; transactions++) {
     time_point<system_clock> sw = system_clock::now();
     
     MDB_txn *txn;
 
     rc = mdb_txn_begin(env, NULL, 0, &txn);
+	rc = mdb_cursor_open(txn, dbi, &cursor);
     
     for(int i = 0; i < itemsPerTransaction; i++) {
       TestData *item = &*begin;
@@ -187,7 +194,7 @@ vector<PerformanceRecord> WriteInternal(vector<TestData>::iterator begin, int it
       data.mv_size = item->ValueSize;
       data.mv_data = sval;
        
-      rc = mdb_put(txn, dbi, &key, &data, 0);
+      rc = mdb_cursor_put(cursor, &key, &data, flag);
       
       if(rc != 0){
 	cout << "Unable to PUT: " << rc << endl;
@@ -215,7 +222,7 @@ vector<PerformanceRecord> WriteInternal(vector<TestData>::iterator begin, int it
   return records;
 }
 
-vector<PerformanceRecord> Write(vector<TestData> dataItems, int itemsPerTransaction, int numberOfTransactions) {
+vector<PerformanceRecord> Write(vector<TestData> dataItems, int itemsPerTransaction, int numberOfTransactions, int seqrand) {
 
   MDB_dbi dbi;
   MDB_env *env = StorageEnvironment(true, &dbi);
@@ -223,7 +230,7 @@ vector<PerformanceRecord> Write(vector<TestData> dataItems, int itemsPerTransact
   time_point<system_clock> start, end;
   start = system_clock::now();
   
-  vector<PerformanceRecord> records = WriteInternal(dataItems.begin(),itemsPerTransaction,numberOfTransactions, env, dbi);
+  vector<PerformanceRecord> records = WriteInternal(dataItems.begin(),itemsPerTransaction,numberOfTransactions, seqrand, env, dbi);
   
   end = system_clock::now();
   
@@ -239,7 +246,7 @@ vector<PerformanceRecord> Write(vector<TestData> dataItems, int itemsPerTransact
   return records;
 };
 
-vector<PerformanceRecord> WriteParallel(vector<TestData> data, int itemsPerTransaction, int numberOfTransactions, int numberOfThreads) {
+vector<PerformanceRecord> WriteParallel(vector<TestData> data, int itemsPerTransaction, int numberOfTransactions, int seqrand, int numberOfThreads) {
   vector<PerformanceRecord> records;
   
   MDB_dbi dbi;
@@ -258,7 +265,7 @@ vector<PerformanceRecord> WriteParallel(vector<TestData> data, int itemsPerTrans
     vector<TestData>::iterator it = data.begin();
     advance(it, d.SkipCount);
     
-    results.at(i) = async(&WriteInternal, it, d.ItemsPerTransaction, d.NumberOfTransactions, env, dbi);
+    results.at(i) = async(&WriteInternal, it, d.ItemsPerTransaction, d.NumberOfTransactions, seqrand, env, dbi);
   }
   
   for(int i = 0; i < numberOfThreads; i++) {
@@ -398,19 +405,19 @@ int main(int argc,char * argv[])
   vector<TestData> sequentialIdsLarge = InitSequentialNumbers(readItems, 512, 87 * 1024);
   vector<TestData> randomIdsLarge = InitRandomNumbers(readItems, 512, 87 * 1024);
   
-  vector<PerformanceRecord> records = Write(sequentialIds, itemsPerTransaction, writeTransactions);
+  vector<PerformanceRecord> records = Write(sequentialIds, itemsPerTransaction, writeTransactions, SEQ);
   WritePerfData("WriteSeq", records);
   
-  records = WriteParallel(sequentialIds, itemsPerTransaction, writeTransactions, 2);
+  records = WriteParallel(sequentialIds, itemsPerTransaction, writeTransactions, SEQ, 2);
   WritePerfData("WriteSeq_Parallel_2", records);
   
-  records = WriteParallel(sequentialIds, itemsPerTransaction, writeTransactions, 4);
+  records = WriteParallel(sequentialIds, itemsPerTransaction, writeTransactions, SEQ, 4);
   WritePerfData("WriteSeq_Parallel_4", records);
   
-  records = WriteParallel(sequentialIds, itemsPerTransaction, writeTransactions, 8);
+  records = WriteParallel(sequentialIds, itemsPerTransaction, writeTransactions, SEQ, 8);
   WritePerfData("WriteSeq_Parallel_8", records);
   
-  records = WriteParallel(sequentialIds, itemsPerTransaction, writeTransactions, 16);
+  records = WriteParallel(sequentialIds, itemsPerTransaction, writeTransactions, SEQ, 16);
   WritePerfData("WriteSeq_Parallel_16", records);
   
   records = Read(sequentialIds, itemsPerTransaction, writeTransactions);
@@ -428,17 +435,17 @@ int main(int argc,char * argv[])
   records = ReadParallel(sequentialIds, itemsPerTransaction, writeTransactions, 16);
   WritePerfData("ReadSeq_Parallel_16", records);
   
-  records = Write(randomIds, itemsPerTransaction, writeTransactions);
+  records = Write(randomIds, itemsPerTransaction, writeTransactions, RND);
   WritePerfData("WriteRandom", records);
   records = Read(randomIds, itemsPerTransaction, writeTransactions);
   WritePerfData("ReadRandom", records);
   
-  records = Write(sequentialIdsLarge, itemsPerTransaction, writeTransactions);
+  records = Write(sequentialIdsLarge, itemsPerTransaction, writeTransactions, SEQ);
   WritePerfData("WriteLargeSeq", records);
   records = Read(sequentialIdsLarge, itemsPerTransaction, writeTransactions);
   WritePerfData("ReadLargeSeq", records);
   
-  records = Write(randomIdsLarge, itemsPerTransaction, writeTransactions);
+  records = Write(randomIdsLarge, itemsPerTransaction, writeTransactions, RND);
   WritePerfData("WriteLargeRandom", records);;
   records = Read(randomIdsLarge, itemsPerTransaction, writeTransactions);
   WritePerfData("ReadLargeRandom", records);


### PR DESCRIPTION
Your read tests didn't use read-only TXNs, so they showed no scaling for parallel reads. With these fixed, on my AMD quadcore laptop I get:

Wrote 10000 items in 0.012149 sec, 823113 ops/s
Write Parallel [2] 10000 items in 0.011838 sec, 844737 ops/s
Write Parallel [4] 10000 items in 0.021464 sec, 465896 ops/s
Write Parallel [8] 10000 items in 0.017587 sec, 568601 ops/s
Write Parallel [16] 10000 items in 0.015424 sec, 648340 ops/s
Read 10000 items in 0.004716 sec, 2120441 ops/s
Read Parallel [2] 20000 items in 0.012886 sec, 1552072 ops/s
Read Parallel [4] 40000 items in 0.014793 sec, 2703981 ops/s
Read Parallel [8] 80000 items in 0.016813 sec, 4758222 ops/s
Read Parallel [16] 160000 items in 0.030883 sec, 5180843 ops/s
Wrote 10000 items in 0.016397 sec, 609867 ops/s
Read 10000 items in 0.004939 sec, 2024701 ops/s
Wrote 10000 items in 0.347584 sec, 28770 ops/s
Read 10000 items in 0.003645 sec, 2743484 ops/s
Wrote 10000 items in 0.356129 sec, 28079 ops/s
Read 10000 items in 0.003839 sec, 2604845 ops/s
