### PR TITLE
tweak to iterator Seek(Slice.BeforeAllKeys) + some commits that accumulated on my branch

### DIFF
--- a/Voron.Tests/Backups/Full.cs
+++ b/Voron.Tests/Backups/Full.cs
@@ -45,7 +45,7 @@ namespace Voron.Tests.Backups
 			{
 				for (int i = 0; i < 500; i++)
 				{
-					tx.State.Root.Add(tx, "items/" + i, new MemoryStream(buffer));
+					tx.State.Root.Add("items/" + i, new MemoryStream(buffer));
 				}
 
 				tx.Commit();
@@ -60,7 +60,7 @@ namespace Voron.Tests.Backups
 			{
 				for (int i = 500; i < 1000; i++)
 				{
-					tx.State.Root.Add(tx, "items/" + i, new MemoryStream(buffer));
+					tx.State.Root.Add("items/" + i, new MemoryStream(buffer));
 				}
 
 				tx.Commit();
@@ -79,7 +79,7 @@ namespace Voron.Tests.Backups
 				{
 					for (int i = 0; i < 1000; i++)
 					{
-						var readResult = tx.State.Root.Read(tx, "items/" + i);
+						var readResult = tx.State.Root.Read("items/" + i);
 						Assert.NotNull(readResult);
 						var memoryStream = new MemoryStream();
 						readResult.Reader.CopyTo(memoryStream);

--- a/Voron.Tests/Backups/Incremental.cs
+++ b/Voron.Tests/Backups/Incremental.cs
@@ -45,7 +45,7 @@ namespace Voron.Tests.Backups
 			{
 				for (int i = 0; i < 500; i++)
 				{
-					tx.State.Root.Add(tx, "items/" + i, new MemoryStream(buffer));
+					tx.State.Root.Add("items/" + i, new MemoryStream(buffer));
 				}
 
 				tx.Commit();
@@ -65,7 +65,7 @@ namespace Voron.Tests.Backups
 				{
 					for (int i = 0; i < 500; i++)
 					{
-						var readResult = tx.State.Root.Read(tx, "items/" + i);
+						var readResult = tx.State.Root.Read("items/" + i);
 						Assert.NotNull(readResult);
 						var memoryStream = new MemoryStream();
 						readResult.Reader.CopyTo(memoryStream);
@@ -88,7 +88,7 @@ namespace Voron.Tests.Backups
 			{
 				for (int i = 0; i < 300; i++)
 				{
-					tx.State.Root.Add(tx, "items/" + i, new MemoryStream(buffer));
+					tx.State.Root.Add("items/" + i, new MemoryStream(buffer));
 				}
 
 				tx.Commit();
@@ -100,7 +100,7 @@ namespace Voron.Tests.Backups
 			{
 				for (int i = 300; i < 600; i++)
 				{
-					tx.State.Root.Add(tx, "items/" + i, new MemoryStream(buffer));
+					tx.State.Root.Add("items/" + i, new MemoryStream(buffer));
 				}
 
 				tx.Commit();
@@ -112,7 +112,7 @@ namespace Voron.Tests.Backups
 			{
 				for (int i = 600; i < 1000; i++)
 				{
-					tx.State.Root.Add(tx, "items/" + i, new MemoryStream(buffer));
+					tx.State.Root.Add("items/" + i, new MemoryStream(buffer));
 				}
 
 				tx.Commit();
@@ -138,7 +138,7 @@ namespace Voron.Tests.Backups
 				{
 					for (int i = 0; i < 1000; i++)
 					{
-						var readResult = tx.State.Root.Read(tx, "items/" + i);
+						var readResult = tx.State.Root.Read("items/" + i);
 						Assert.NotNull(readResult);
 						var memoryStream = new MemoryStream();
 						readResult.Reader.CopyTo(memoryStream);
@@ -160,7 +160,7 @@ namespace Voron.Tests.Backups
 			{
 				for (int i = 0; i < 5; i++)
 				{
-					tx.State.Root.Add(tx, "items/" + i, new MemoryStream(buffer));
+					tx.State.Root.Add("items/" + i, new MemoryStream(buffer));
 				}
 
 				tx.Commit();
@@ -178,7 +178,7 @@ namespace Voron.Tests.Backups
 			{
 				for (int i = 5; i < 10; i++)
 				{
-					tx.State.Root.Add(tx, "items/" + i, new MemoryStream(buffer));
+					tx.State.Root.Add("items/" + i, new MemoryStream(buffer));
 				}
 
 				tx.Commit();
@@ -205,7 +205,7 @@ namespace Voron.Tests.Backups
 				{
 					for (int i = 0; i < 10; i++)
 					{
-						var readResult = tx.State.Root.Read(tx, "items/" + i);
+						var readResult = tx.State.Root.Read("items/" + i);
 						Assert.NotNull(readResult);
 						var memoryStream = new MemoryStream();
 						readResult.Reader.CopyTo(memoryStream);

--- a/Voron.Tests/Backups/Incremental.cs
+++ b/Voron.Tests/Backups/Incremental.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using Voron.Impl;
 using Voron.Impl.Backup;
 using Voron.Impl.Paging;

--- a/Voron.Tests/Bugs/AccessViolationWithIteratorUsage.cs
+++ b/Voron.Tests/Bugs/AccessViolationWithIteratorUsage.cs
@@ -1,0 +1,60 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="AccessViolationWithIteratorUsage.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System.IO;
+using Xunit;
+
+namespace Voron.Tests.Bugs
+{
+	public class AccessViolationWithIteratorUsage : StorageTest
+	{
+		protected override void Configure(StorageEnvironmentOptions options)
+		{
+			options.ManualFlushing = true;
+		}
+
+		[Fact]
+		public void ShouldNotThrow()
+		{
+			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				var tree = Env.CreateTree(tx, "test");
+
+				tree.Add(tx, "items/1", new MemoryStream());
+				tree.Add(tx, "items/2", new MemoryStream());
+
+				tx.Commit();
+			}
+
+			using (var snapshot = Env.CreateSnapshot())
+			using (var iterator = snapshot.Iterate("test"))
+			{
+				using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+				{
+					for (int i = 0; i < 10; i++)
+					{
+						Env.State.GetTree(tx, "test").Add(tx, "items/" + i, new MemoryStream(new byte[2048]));
+					}
+
+					tx.Commit();
+				}
+
+				Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+
+				using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+				{
+					for (int i = 10; i < 40; i++)
+					{
+						Env.State.GetTree(tx, "test").Add(tx, "items/" + i, new MemoryStream(new byte[2048]));
+					}
+
+					tx.Commit();
+				}
+
+				iterator.MoveNext();
+			}
+		}
+	}
+}

--- a/Voron.Tests/Bugs/AccessViolationWithIteratorUsage.cs
+++ b/Voron.Tests/Bugs/AccessViolationWithIteratorUsage.cs
@@ -22,8 +22,8 @@ namespace Voron.Tests.Bugs
 			{
 				var tree = Env.CreateTree(tx, "test");
 
-				tree.Add(tx, "items/1", new MemoryStream());
-				tree.Add(tx, "items/2", new MemoryStream());
+				tree.Add("items/1", new MemoryStream());
+				tree.Add("items/2", new MemoryStream());
 
 				tx.Commit();
 			}
@@ -35,7 +35,7 @@ namespace Voron.Tests.Bugs
 				{
 					for (int i = 0; i < 10; i++)
 					{
-						Env.State.GetTree(tx, "test").Add(tx, "items/" + i, new MemoryStream(new byte[2048]));
+						Env.State.GetTree(tx, "test").Add("items/" + i, new MemoryStream(new byte[2048]));
 					}
 
 					tx.Commit();
@@ -47,7 +47,7 @@ namespace Voron.Tests.Bugs
 				{
 					for (int i = 10; i < 40; i++)
 					{
-						Env.State.GetTree(tx, "test").Add(tx, "items/" + i, new MemoryStream(new byte[2048]));
+						Env.State.GetTree(tx, "test").Add("items/" + i, new MemoryStream(new byte[2048]));
 					}
 
 					tx.Commit();

--- a/Voron.Tests/Bugs/ChecksumMismatchAfterRecovery.cs
+++ b/Voron.Tests/Bugs/ChecksumMismatchAfterRecovery.cs
@@ -45,7 +45,7 @@ namespace Voron.Tests.Bugs
 				{
 					for (int i = 0; i < 50; i++)
 					{
-						tx.State.Root.Add(tx, "items/" + i, new MemoryStream(buffer));
+						tx.State.Root.Add("items/" + i, new MemoryStream(buffer));
 					}
 
 					tx.Commit();
@@ -55,7 +55,7 @@ namespace Voron.Tests.Bugs
 				{
 					for (int i = 50; i < 100; i++)
 					{
-						tx.State.Root.Add(tx, "items/" + i, new MemoryStream(buffer));
+						tx.State.Root.Add("items/" + i, new MemoryStream(buffer));
 					}
 
 					tx.Commit();
@@ -71,7 +71,7 @@ namespace Voron.Tests.Bugs
 
 					for (int i = 0; i < 100; i++)
 					{
-						var readResult = tx.State.Root.Read(tx, "items/" + i);
+						var readResult = tx.State.Root.Read("items/" + i);
 						Assert.NotNull(readResult);
 						var memoryStream = new MemoryStream();
 						readResult.Reader.CopyTo(memoryStream);

--- a/Voron.Tests/Bugs/Deletes.cs
+++ b/Voron.Tests/Bugs/Deletes.cs
@@ -49,7 +49,7 @@
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
 			    var t1 = tx.Environment.State.GetTree(tx,"tree1");
-				t1.Delete(tx, "Foo180"); // rebalancer fails to move 1st node from one branch to another
+				t1.Delete("Foo180"); // rebalancer fails to move 1st node from one branch to another
 			}
 		}
 	}

--- a/Voron.Tests/Bugs/EmptyTree.cs
+++ b/Voron.Tests/Bugs/EmptyTree.cs
@@ -18,7 +18,7 @@ namespace Voron.Tests.Bugs
 
             using (var tx = Env.NewTransaction(TransactionFlags.Read))
             {
-                var treeIterator = tx.Environment.State.GetTree(tx,"events").Iterate(tx);
+                var treeIterator = tx.Environment.State.GetTree(tx,"events").Iterate();
 
                 Assert.False(treeIterator.Seek(Slice.AfterAllKeys));
 
@@ -43,7 +43,7 @@ namespace Voron.Tests.Bugs
 
                     using (var tx = env.NewTransaction(TransactionFlags.ReadWrite))
                     {
-                        tx.Environment.State.GetTree(tx,"events").Add(tx, "test", new MemoryStream(0));
+                        tx.Environment.State.GetTree(tx,"events").Add("test", new MemoryStream(0));
 
                         tx.Commit();
                     }
@@ -61,7 +61,7 @@ namespace Voron.Tests.Bugs
                     using (var tx = env.NewTransaction(TransactionFlags.ReadWrite))
                     {
                         var tree = tx.Environment.State.GetTree(tx,"events");
-                        var readResult = tree.Read(tx, "test");
+                        var readResult = tree.Read("test");
                         Assert.NotNull(readResult);
 
                         tx.Commit();

--- a/Voron.Tests/Bugs/FlushingToDataFile.cs
+++ b/Voron.Tests/Bugs/FlushingToDataFile.cs
@@ -36,14 +36,14 @@ namespace Voron.Tests.Bugs
 
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                tx.State.Root.Add(tx, "foo/0", new MemoryStream(value1));
+                tx.State.Root.Add("foo/0", new MemoryStream(value1));
 
                 tx.Commit();
             }
 
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                tx.State.Root.Add(tx, "foo/1", new MemoryStream(value1));
+                tx.State.Root.Add("foo/1", new MemoryStream(value1));
 
                 tx.Commit();
             }
@@ -60,7 +60,7 @@ namespace Voron.Tests.Bugs
 
                 for (var i = 0; i < 2; i++)
                 {
-                    var readResult = tx.State.Root.Read(tx, "foo/" + i);
+                    var readResult = tx.State.Root.Read("foo/" + i);
 
                     Assert.NotNull(readResult);
                     Assert.Equal(value1.Length, readResult.Reader.Length);
@@ -88,29 +88,29 @@ namespace Voron.Tests.Bugs
 
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                tx.State.Root.Add(tx, "foo/0", new MemoryStream(value1));
-                tx.State.Root.Add(tx, "foo/1", new MemoryStream(value1));
+                tx.State.Root.Add("foo/0", new MemoryStream(value1));
+                tx.State.Root.Add("foo/1", new MemoryStream(value1));
 
                 tx.Commit();
             }
 
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                tx.State.Root.Add(tx, "foo/0", new MemoryStream(value1));
+                tx.State.Root.Add("foo/0", new MemoryStream(value1));
 
                 tx.Commit();
             }
 
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                tx.State.Root.Add(tx, "foo/4", new MemoryStream(value1));
+                tx.State.Root.Add("foo/4", new MemoryStream(value1));
                 tx.Commit();
             }
 
 
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                var readResult = tx.State.Root.Read(tx, "foo/0");
+                var readResult = tx.State.Root.Read("foo/0");
 
                 Assert.NotNull(readResult);
                 Assert.Equal(value1.Length, readResult.Reader.Length);
@@ -126,7 +126,7 @@ namespace Voron.Tests.Bugs
 
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                var readResult = tx.State.Root.Read(tx, "foo/0");
+                var readResult = tx.State.Root.Read("foo/0");
 
                 Assert.NotNull(readResult);
                 Assert.Equal(value1.Length, readResult.Reader.Length);
@@ -164,7 +164,7 @@ namespace Voron.Tests.Bugs
                         {
                             foreach (var tree in trees)
                             {
-                                tx.Environment.State.GetTree(tx,tree).Add(tx, string.Format("key/{0}/{1}", a, i), new MemoryStream(buffer));
+                                tx.Environment.State.GetTree(tx,tree).Add(string.Format("key/{0}/{1}", a, i), new MemoryStream(buffer));
                             }
 
                         }
@@ -183,7 +183,7 @@ namespace Voron.Tests.Bugs
                 {
                     foreach (var tree in trees)
                     {
-                        using (var iterator = tx.Environment.State.GetTree(tx,tree).Iterate(tx))
+                        using (var iterator = tx.Environment.State.GetTree(tx,tree).Iterate())
                         {
                             if (!iterator.Seek(Slice.BeforeAllKeys))
                                 continue;

--- a/Voron.Tests/Bugs/IndexPointToNonLeafPageTests.cs
+++ b/Voron.Tests/Bugs/IndexPointToNonLeafPageTests.cs
@@ -33,7 +33,7 @@ namespace Voron.Tests.Bugs
 					{
 						enumerator.MoveNext();
 
-						tx.State.Root.Add(tx, enumerator.Current.Key.ToString("0000000000000000"), new MemoryStream(enumerator.Current.Value));
+						tx.State.Root.Add(enumerator.Current.Key.ToString("0000000000000000"), new MemoryStream(enumerator.Current.Value));
 					}
 
 					tx.Commit();
@@ -46,7 +46,7 @@ namespace Voron.Tests.Bugs
 			{
 				foreach (var item in sequentialLargeIds)
 				{
-					var readResult = tx.State.Root.Read(tx, item.Key.ToString("0000000000000000"));
+					var readResult = tx.State.Root.Read(item.Key.ToString("0000000000000000"));
 
 					Assert.NotNull(readResult);
 

--- a/Voron.Tests/Bugs/InvalidReleasesOfScratchPages.cs
+++ b/Voron.Tests/Bugs/InvalidReleasesOfScratchPages.cs
@@ -22,12 +22,12 @@ namespace Voron.Tests.Bugs
 
 				using (var txw = env.NewTransaction(TransactionFlags.ReadWrite))
 				{
-					txw.Environment.State.GetTree(txw, "tree0").Add(txw, "key/1", new MemoryStream());
+					txw.Environment.State.GetTree(txw, "tree0").Add("key/1", new MemoryStream());
 					txw.Commit();
 
 					using (var txr = env.NewTransaction(TransactionFlags.Read))
 					{
-						Assert.NotNull(txr.Environment.State.GetTree(txr, "tree0").Read(txr, "key/1"));
+						Assert.NotNull(txr.Environment.State.GetTree(txr, "tree0").Read("key/1"));
 					}
 				}
 			}

--- a/Voron.Tests/Bugs/Isolation.cs
+++ b/Voron.Tests/Bugs/Isolation.cs
@@ -1,88 +1,195 @@
-﻿namespace Voron.Tests.Bugs
+﻿using System.Collections.Generic;
+
+namespace Voron.Tests.Bugs
 {
-    using System.IO;
+	using System.IO;
 
-    using Xunit;
+	using Xunit;
 
-    public class Isolation : StorageTest
-    {
-        [Fact]
-        public void ScratchPagesShouldNotBeReleasedUntilNotUsed()
-        {
-            var directory = "Test2";
+	public class Isolation : StorageTest
+	{
+		[Fact]
+		public void MultiTreeIteratorShouldBeIsolated1()
+		{
+			var directory = "Test2";
 
-            if (Directory.Exists(directory))
-                Directory.Delete(directory, true);
+			DeleteDirectory(directory);
 
-            var options = StorageEnvironmentOptions.ForPath(directory);
+			var options = StorageEnvironmentOptions.ForPath(directory);
 
-            options.ManualFlushing = true;
-            using (var env = new StorageEnvironment(options))
-            {
-                CreateTrees(env, 2, "tree");
-                for (int a = 0; a < 3; a++)
-                {
-                    using (var tx = env.NewTransaction(TransactionFlags.ReadWrite))
-                    {
-                        tx.Environment.State.GetTree(tx,"tree0").Add(tx, string.Format("key/{0}/{1}/1", new string('0', 1000), a), new MemoryStream());
-                        tx.Environment.State.GetTree(tx,"tree0").Add(tx, string.Format("key/{0}/{1}/2", new string('0', 1000), a), new MemoryStream());
+			using (var env = new StorageEnvironment(options))
+			{
+				CreateTrees(env, 1, "tree");
 
-                        tx.Commit();
-                    }
-                }
+				for (var i = 0; i < 10; i++)
+					Write(env, i);
 
-                using (var tx = env.NewTransaction(TransactionFlags.ReadWrite))
-                {
-                    tx.Environment.State.GetTree(tx,"tree1").Add(tx, "yek/1", new MemoryStream());
+				using (var txr = env.NewTransaction(TransactionFlags.Read))
+				{
+					var key = Write(env, 10);
 
-                    tx.Commit();
-                }
+					using (var iterator = txr.ReadTree("tree0").MultiRead(txr, "key/1"))
+					{
+						Assert.True(iterator.Seek(Slice.BeforeAllKeys));
 
-                using (var txr = env.NewTransaction(TransactionFlags.Read))
-                {
-                    using (var iterator = txr.Environment.State.GetTree(txr, "tree0").Iterate(txr))
-                    {
-                        Assert.True(iterator.Seek(Slice.BeforeAllKeys)); // all pages are from scratch (one from position 11)
+						var count = 0;
 
-                        var currentKey = iterator.CurrentKey.ToString();
+						do
+						{
+							Assert.True(iterator.CurrentKey.ToString() != key, string.Format("Key '{0}' should not be present in multi-iterator", key));
 
-                        env.FlushLogToDataFile(); // frees pages from scratch (including the one at position 11)
+							count++;
+						}
+						while (iterator.MoveNext());
 
-                        using (var txw = env.NewTransaction(TransactionFlags.ReadWrite))
-                        {
-                            var tree = txw.Environment.State.GetTree(txw, "tree1");
-                            tree.Add(txw, string.Format("yek/{0}/0/0", new string('0', 1000)), new MemoryStream()); // allocates new page from scratch (position 11)
+						Assert.Equal(10, count);
+					}
+				}
+			}
+		}
 
-                            txw.Commit();
-                        }
+		[Fact]
+		public void MultiTreeIteratorShouldBeIsolated2()
+		{
+			var directory = "Test2";
+
+			DeleteDirectory(directory);
+
+			var options = StorageEnvironmentOptions.ForPath(directory);
+
+			using (var env = new StorageEnvironment(options))
+			{
+				CreateTrees(env, 1, "tree");
+
+				for (var i = 0; i < 11; i++)
+					Write(env, i);
+
+				using (var txr = env.NewTransaction(TransactionFlags.Read))
+				{
+					var key = Delete(env, 10);
+
+					using (var iterator = txr.ReadTree("tree0").MultiRead(txr, "key/1"))
+					{
+						Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+
+						var keys = new List<string>();
+
+						do
+						{
+							keys.Add(iterator.CurrentKey.ToString());
+						}
+						while (iterator.MoveNext());
+
+						Assert.Equal(11, keys.Count);
+						Assert.Contains(key, keys);
+					}
+				}
+			}
+		}
+
+		private static string Delete(StorageEnvironment env, int i)
+		{
+			using (var txw = env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				var key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" + i.ToString("D2");
+
+				txw.ReadTree("tree0").MultiDelete(txw, "key/1", key);
+				txw.Commit();
+
+				return key;
+			}
+		}
+
+		private static string Write(StorageEnvironment env, int i)
+		{
+			using (var txw = env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				var key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" + i.ToString("D2");
+
+				txw.ReadTree("tree0").MultiAdd(txw, "key/1", key);
+				txw.Commit();
+
+				return key;
+			}
+		}
+
+		[Fact]
+		public void ScratchPagesShouldNotBeReleasedUntilNotUsed()
+		{
+			var directory = "Test2";
+
+			if (Directory.Exists(directory))
+				Directory.Delete(directory, true);
+
+			var options = StorageEnvironmentOptions.ForPath(directory);
+
+			options.ManualFlushing = true;
+			using (var env = new StorageEnvironment(options))
+			{
+				CreateTrees(env, 2, "tree");
+				for (int a = 0; a < 3; a++)
+				{
+					using (var tx = env.NewTransaction(TransactionFlags.ReadWrite))
+					{
+						tx.Environment.State.GetTree(tx, "tree0").Add(tx, string.Format("key/{0}/{1}/1", new string('0', 1000), a), new MemoryStream());
+						tx.Environment.State.GetTree(tx, "tree0").Add(tx, string.Format("key/{0}/{1}/2", new string('0', 1000), a), new MemoryStream());
+
+						tx.Commit();
+					}
+				}
+
+				using (var tx = env.NewTransaction(TransactionFlags.ReadWrite))
+				{
+					tx.Environment.State.GetTree(tx, "tree1").Add(tx, "yek/1", new MemoryStream());
+
+					tx.Commit();
+				}
+
+				using (var txr = env.NewTransaction(TransactionFlags.Read))
+				{
+					using (var iterator = txr.Environment.State.GetTree(txr, "tree0").Iterate(txr))
+					{
+						Assert.True(iterator.Seek(Slice.BeforeAllKeys)); // all pages are from scratch (one from position 11)
+
+						var currentKey = iterator.CurrentKey.ToString();
+
+						env.FlushLogToDataFile(); // frees pages from scratch (including the one at position 11)
+
+						using (var txw = env.NewTransaction(TransactionFlags.ReadWrite))
+						{
+							var tree = txw.Environment.State.GetTree(txw, "tree1");
+							tree.Add(txw, string.Format("yek/{0}/0/0", new string('0', 1000)), new MemoryStream()); // allocates new page from scratch (position 11)
+
+							txw.Commit();
+						}
 
 						Assert.Equal(currentKey, iterator.CurrentKey.ToString());
 
 						using (var txw = env.NewTransaction(TransactionFlags.ReadWrite))
-                        {
-                            var tree = txw.Environment.State.GetTree(txw, "tree1");
-                            tree.Add(txw, "fake", new MemoryStream());
+						{
+							var tree = txw.Environment.State.GetTree(txw, "tree1");
+							tree.Add(txw, "fake", new MemoryStream());
 
-                            txw.Commit();
-                        }
+							txw.Commit();
+						}
 
-                        Assert.Equal(currentKey, iterator.CurrentKey.ToString());
+						Assert.Equal(currentKey, iterator.CurrentKey.ToString());
 
-                        var count = 0;
+						var count = 0;
 
-                        do
-                        {
-                            currentKey = iterator.CurrentKey.ToString();
-                            count++;
+						do
+						{
+							currentKey = iterator.CurrentKey.ToString();
+							count++;
 
-                            Assert.Contains("key/", currentKey);
-                        }
-                        while (iterator.MoveNext());
+							Assert.Contains("key/", currentKey);
+						}
+						while (iterator.MoveNext());
 
-                        Assert.Equal(6, count);
-                    }
-                }
-            }
-        }
-    }
+						Assert.Equal(6, count);
+					}
+				}
+			}
+		}
+	}
 }

--- a/Voron.Tests/Bugs/Isolation.cs
+++ b/Voron.Tests/Bugs/Isolation.cs
@@ -28,7 +28,7 @@ namespace Voron.Tests.Bugs
 				{
 					var key = Write(env, 10);
 
-					using (var iterator = txr.ReadTree("tree0").MultiRead(txr, "key/1"))
+					using (var iterator = txr.ReadTree("tree0").MultiRead("key/1"))
 					{
 						Assert.True(iterator.Seek(Slice.BeforeAllKeys));
 
@@ -68,7 +68,7 @@ namespace Voron.Tests.Bugs
 				{
 					var key = Delete(env, 10);
 
-					using (var iterator = txr.ReadTree("tree0").MultiRead(txr, "key/1"))
+					using (var iterator = txr.ReadTree("tree0").MultiRead("key/1"))
 					{
 						Assert.True(iterator.Seek(Slice.BeforeAllKeys));
 
@@ -93,7 +93,7 @@ namespace Voron.Tests.Bugs
 			{
 				var key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" + i.ToString("D2");
 
-				txw.ReadTree("tree0").MultiDelete(txw, "key/1", key);
+				txw.ReadTree("tree0").MultiDelete("key/1", key);
 				txw.Commit();
 
 				return key;
@@ -106,7 +106,7 @@ namespace Voron.Tests.Bugs
 			{
 				var key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" + i.ToString("D2");
 
-				txw.ReadTree("tree0").MultiAdd(txw, "key/1", key);
+				txw.ReadTree("tree0").MultiAdd("key/1", key);
 				txw.Commit();
 
 				return key;
@@ -131,8 +131,8 @@ namespace Voron.Tests.Bugs
 				{
 					using (var tx = env.NewTransaction(TransactionFlags.ReadWrite))
 					{
-						tx.Environment.State.GetTree(tx, "tree0").Add(tx, string.Format("key/{0}/{1}/1", new string('0', 1000), a), new MemoryStream());
-						tx.Environment.State.GetTree(tx, "tree0").Add(tx, string.Format("key/{0}/{1}/2", new string('0', 1000), a), new MemoryStream());
+						tx.Environment.State.GetTree(tx, "tree0").Add(string.Format("key/{0}/{1}/1", new string('0', 1000), a), new MemoryStream());
+						tx.Environment.State.GetTree(tx, "tree0").Add(string.Format("key/{0}/{1}/2", new string('0', 1000), a), new MemoryStream());
 
 						tx.Commit();
 					}
@@ -140,14 +140,14 @@ namespace Voron.Tests.Bugs
 
 				using (var tx = env.NewTransaction(TransactionFlags.ReadWrite))
 				{
-					tx.Environment.State.GetTree(tx, "tree1").Add(tx, "yek/1", new MemoryStream());
+					tx.Environment.State.GetTree(tx, "tree1").Add("yek/1", new MemoryStream());
 
 					tx.Commit();
 				}
 
 				using (var txr = env.NewTransaction(TransactionFlags.Read))
 				{
-					using (var iterator = txr.Environment.State.GetTree(txr, "tree0").Iterate(txr))
+					using (var iterator = txr.Environment.State.GetTree(txr, "tree0").Iterate())
 					{
 						Assert.True(iterator.Seek(Slice.BeforeAllKeys)); // all pages are from scratch (one from position 11)
 
@@ -158,7 +158,7 @@ namespace Voron.Tests.Bugs
 						using (var txw = env.NewTransaction(TransactionFlags.ReadWrite))
 						{
 							var tree = txw.Environment.State.GetTree(txw, "tree1");
-							tree.Add(txw, string.Format("yek/{0}/0/0", new string('0', 1000)), new MemoryStream()); // allocates new page from scratch (position 11)
+							tree.Add(string.Format("yek/{0}/0/0", new string('0', 1000)), new MemoryStream()); // allocates new page from scratch (position 11)
 
 							txw.Commit();
 						}
@@ -168,7 +168,7 @@ namespace Voron.Tests.Bugs
 						using (var txw = env.NewTransaction(TransactionFlags.ReadWrite))
 						{
 							var tree = txw.Environment.State.GetTree(txw, "tree1");
-							tree.Add(txw, "fake", new MemoryStream());
+							tree.Add("fake", new MemoryStream());
 
 							txw.Commit();
 						}

--- a/Voron.Tests/Bugs/Iterating.cs
+++ b/Voron.Tests/Bugs/Iterating.cs
@@ -1,0 +1,40 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="Iterating.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using Xunit;
+
+namespace Voron.Tests.Bugs
+{
+	public class Iterating : StorageTest
+	{
+		[Fact]
+		public void IterationShouldNotFindAnyRecordsAndShouldNotThrowWhenNumberOfEntriesOnPageIs1AndKeyDoesNotMatch()
+		{
+			using (var env = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()))
+			{
+				using (var tx = env.NewTransaction(TransactionFlags.ReadWrite))
+				{
+					env.CreateTree(tx, "tree");
+
+					tx.Commit();
+				}
+
+				using (var tx = env.NewTransaction(TransactionFlags.ReadWrite))
+				{
+					var tree = tx.ReadTree("tree");
+					tree.Add(tx, @"Raven\Database\1", StreamFor("123"));
+
+					tx.Commit();
+				}
+
+				using (var snapshot = env.CreateSnapshot())
+				using (var iterator = snapshot.Iterate("tree"))
+				{
+					Assert.False(iterator.Seek(@"Raven\Filesystem\"));
+				}
+			}
+		}
+	}
+}

--- a/Voron.Tests/Bugs/Iterating.cs
+++ b/Voron.Tests/Bugs/Iterating.cs
@@ -24,7 +24,7 @@ namespace Voron.Tests.Bugs
 				using (var tx = env.NewTransaction(TransactionFlags.ReadWrite))
 				{
 					var tree = tx.ReadTree("tree");
-					tree.Add(tx, @"Raven\Database\1", StreamFor("123"));
+					tree.Add(@"Raven\Database\1", StreamFor("123"));
 
 					tx.Commit();
 				}

--- a/Voron.Tests/Bugs/LargeValues.cs
+++ b/Voron.Tests/Bugs/LargeValues.cs
@@ -32,7 +32,7 @@
                         {
                             enumerator.MoveNext();
 
-                            tx.State.Root.Add(tx, enumerator.Current.Key.ToString("0000000000000000"), new MemoryStream(enumerator.Current.Value));
+                            tx.State.Root.Add(enumerator.Current.Key.ToString("0000000000000000"), new MemoryStream(enumerator.Current.Value));
                         }
 
                         tx.Commit();

--- a/Voron.Tests/Bugs/MemoryAccess.cs
+++ b/Voron.Tests/Bugs/MemoryAccess.cs
@@ -23,8 +23,8 @@ namespace Voron.Tests.Bugs
 				{
 					foreach (var tree in trees)
 					{
-						tx.State.GetTree(tx, tree).Add(tx, string.Format("key/{0}/{1}/1", new string('0', 1000), a), new MemoryStream());
-						tx.State.GetTree(tx, tree).Add(tx, string.Format("key/{0}/{1}/2", new string('0', 1000), a), new MemoryStream());
+						tx.State.GetTree(tx, tree).Add(string.Format("key/{0}/{1}/1", new string('0', 1000), a), new MemoryStream());
+						tx.State.GetTree(tx, tree).Add(string.Format("key/{0}/{1}/2", new string('0', 1000), a), new MemoryStream());
 					}
 
 					tx.Commit();
@@ -35,7 +35,7 @@ namespace Voron.Tests.Bugs
 			{
 				foreach (var tree in trees)
 				{
-					using (var iterator = txr.State.GetTree(txr, tree).Iterate(txr))
+					using (var iterator = txr.State.GetTree(txr, tree).Iterate())
 					{
 						if (!iterator.Seek(Slice.BeforeAllKeys))
 							continue;
@@ -44,7 +44,7 @@ namespace Voron.Tests.Bugs
 
 						using (var txw = Env.NewTransaction(TransactionFlags.ReadWrite))
 						{
-							txw.State.GetTree(txw, tree).Add(txw, string.Format("key/{0}/0/0", new string('0', 1000)), new MemoryStream());
+							txw.State.GetTree(txw, tree).Add(string.Format("key/{0}/0/0", new string('0', 1000)), new MemoryStream());
 
 							txw.Commit();
 						}

--- a/Voron.Tests/Bugs/MultiAdds.cs
+++ b/Voron.Tests/Bugs/MultiAdds.cs
@@ -233,6 +233,7 @@ namespace Voron.Tests.Bugs
 			{
 				for (var j = 0; j < 10; j++)
 				{
+					
 					foreach (var treeName in trees)
 					{
 					    var tree = tx.Environment.State.GetTree(tx,treeName);

--- a/Voron.Tests/Bugs/MultiAdds.cs
+++ b/Voron.Tests/Bugs/MultiAdds.cs
@@ -57,7 +57,7 @@ namespace Voron.Tests.Bugs
 					var tree = tx.Environment.State.GetTree(tx,"foo");
 					foreach (var buffer in inputData)
 					{						
-						Assert.DoesNotThrow(() => tree.MultiAdd(tx, "ChildTreeKey", new Slice(buffer)));
+						Assert.DoesNotThrow(() => tree.MultiAdd("ChildTreeKey", new Slice(buffer)));
 					}
 					tx.Commit();
 				}
@@ -68,7 +68,7 @@ namespace Voron.Tests.Bugs
 					for (int i = 0; i < inputData.Count; i++)
 					{
 						var buffer = inputData[i];
-						Assert.DoesNotThrow(() => tree.MultiDelete(tx, "ChildTreeKey", new Slice(buffer)));
+						Assert.DoesNotThrow(() => tree.MultiDelete("ChildTreeKey", new Slice(buffer)));
 					}
 
 					tx.Commit();
@@ -125,7 +125,7 @@ namespace Voron.Tests.Bugs
 				using (var tx = env.NewTransaction(TransactionFlags.Read))
 				{
 					var tree = tx.Environment.State.GetTree(tx,"multi");
-					using (var iterator = tree.MultiRead(tx, "0"))
+					using (var iterator = tree.MultiRead("0"))
 					{
 						Assert.True(iterator.Seek(Slice.BeforeAllKeys));
 
@@ -153,7 +153,7 @@ namespace Voron.Tests.Bugs
 				using (var tx = env.NewTransaction(TransactionFlags.Read))
 				{
 					var tree = tx.Environment.State.GetTree(tx,"multi");
-					using (var iterator = tree.MultiRead(tx, "0"))
+					using (var iterator = tree.MultiRead("0"))
 					{
 						Assert.True(iterator.Seek(Slice.BeforeAllKeys));
 
@@ -190,7 +190,7 @@ namespace Voron.Tests.Bugs
 				using (var tx = env.NewTransaction(TransactionFlags.Read))
 				{
 					var tree = tx.Environment.State.GetTree(tx,"multitree0");
-					using (var it = tree.MultiRead(tx, "key"))
+					using (var it = tree.MultiRead("key"))
 					{
 						Assert.True(it.Seek(Slice.BeforeAllKeys));
 
@@ -209,7 +209,7 @@ namespace Voron.Tests.Bugs
 			{
 				foreach (var tree in trees)
 				{
-					using (var iterator = tree.Iterate(tx))
+					using (var iterator = tree.Iterate())
 					{
 						Assert.True(iterator.Seek(Slice.BeforeAllKeys));
 
@@ -237,7 +237,7 @@ namespace Voron.Tests.Bugs
 					foreach (var treeName in trees)
 					{
 					    var tree = tx.Environment.State.GetTree(tx,treeName);
-						using (var iterator = tree.MultiRead(tx, (j % 10).ToString()))
+						using (var iterator = tree.MultiRead((j % 10).ToString()))
 						{
 							Assert.True(iterator.Seek(Slice.BeforeAllKeys));
 

--- a/Voron.Tests/Bugs/MultiReads.cs
+++ b/Voron.Tests/Bugs/MultiReads.cs
@@ -1,0 +1,38 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MultiReads.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using Xunit;
+
+namespace Voron.Tests.Bugs
+{
+	public class MultiReads : StorageTest
+	{
+		[Fact]
+		public void MultiReadShouldKeepItemOrder()
+		{
+			foreach (var treeName in CreateTrees(Env, 1, "tree"))
+			{
+				using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+				{
+					tx.ReadTree(treeName).MultiAdd(tx, "queue1", "queue1/07000000-0000-0000-0000-000000000001");
+					tx.ReadTree(treeName).MultiAdd(tx, "queue1", "queue1/07000000-0000-0000-0000-000000000002");
+
+					tx.Commit();
+				}
+
+				using (var snapshot = Env.CreateSnapshot())
+				using (var iterator = snapshot.MultiRead(treeName, "queue1"))
+				{
+					Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+
+					Assert.Equal("queue1/07000000-0000-0000-0000-000000000001", iterator.CurrentKey.ToString());
+					Assert.True(iterator.MoveNext());
+					Assert.Equal("queue1/07000000-0000-0000-0000-000000000002", iterator.CurrentKey.ToString());
+					Assert.False(iterator.MoveNext());
+				}
+			}
+		}
+	}
+}

--- a/Voron.Tests/Bugs/MultiReads.cs
+++ b/Voron.Tests/Bugs/MultiReads.cs
@@ -16,8 +16,8 @@ namespace Voron.Tests.Bugs
 			{
 				using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 				{
-					tx.ReadTree(treeName).MultiAdd(tx, "queue1", "queue1/07000000-0000-0000-0000-000000000001");
-					tx.ReadTree(treeName).MultiAdd(tx, "queue1", "queue1/07000000-0000-0000-0000-000000000002");
+					tx.ReadTree(treeName).MultiAdd("queue1", "queue1/07000000-0000-0000-0000-000000000001");
+					tx.ReadTree(treeName).MultiAdd("queue1", "queue1/07000000-0000-0000-0000-000000000002");
 
 					tx.Commit();
 				}

--- a/Voron.Tests/Bugs/PageSplitter.cs
+++ b/Voron.Tests/Bugs/PageSplitter.cs
@@ -50,7 +50,7 @@ namespace Voron.Tests.Bugs
                 for (int index = 0; index < inputData.Count; index++)
                 {
                     var keyString = inputData[index];
-                    Assert.DoesNotThrow(() => tree.Add(tx, keyString, new MemoryStream(new byte[] { 1, 2, 3, 4 })));
+                    Assert.DoesNotThrow(() => tree.Add(keyString, new MemoryStream(new byte[] { 1, 2, 3, 4 })));
                 }
 
                 tx.Commit();
@@ -79,7 +79,7 @@ namespace Voron.Tests.Bugs
                         {
                             var tree = tx.Environment.State.GetTree(tx, treeName);
 
-                            tree.Add(tx, id, new MemoryStream(testBuffer));
+                            tree.Add(id, new MemoryStream(testBuffer));
                         }
 
                         tx.Commit();
@@ -112,9 +112,9 @@ namespace Voron.Tests.Bugs
                     {
                         var tree = tx.Environment.State.GetTree(tx, treeName);
 
-                        tree.Add(tx, id, new MemoryStream(testBuffer));
+                        tree.Add(id, new MemoryStream(testBuffer));
 
-                        var readResult = tree.Read(tx, id);
+                        var readResult = tree.Read(id);
 
                         Assert.NotNull(readResult);
                     }
@@ -148,7 +148,7 @@ namespace Voron.Tests.Bugs
                         foreach (var treeName in trees)
                         {
                             var tree = tx.Environment.State.GetTree(tx, treeName);
-                            tree.Add(tx, id, new MemoryStream(testBuffer));
+                            tree.Add(id, new MemoryStream(testBuffer));
                         }
 
                         tx.Commit();

--- a/Voron.Tests/Bugs/PageTableIssue.cs
+++ b/Voron.Tests/Bugs/PageTableIssue.cs
@@ -24,7 +24,7 @@ namespace Voron.Tests.Bugs
 				var tree2 = Env.CreateTree(txw, "bar");
 				var tree3 = Env.CreateTree(txw, "baz");
 
-				tree1.Add(txw, "foos/1", new MemoryStream(bytes));
+				tree1.Add("foos/1", new MemoryStream(bytes));
 
 				txw.Commit();
 
@@ -35,7 +35,7 @@ namespace Voron.Tests.Bugs
 			{
 				var tree = Env.State.GetTree(txw, "bar");
 
-				tree.Add(txw, "bars/1", new MemoryStream(bytes));
+				tree.Add("bars/1", new MemoryStream(bytes));
 
 				txw.Commit();
 
@@ -52,7 +52,7 @@ namespace Voron.Tests.Bugs
 
 				// here we have to put a big value to be sure that in next transaction we will put the
 				// updated value into a new journal file - this is the key to expose the issue
-				tree.Add(txw, "bazs/1", new MemoryStream(bytesToFillFirstJournalCompletely));
+				tree.Add("bazs/1", new MemoryStream(bytesToFillFirstJournalCompletely));
 
 				txw.Commit();
 
@@ -65,7 +65,7 @@ namespace Voron.Tests.Bugs
 				{
 					var tree = Env.State.GetTree(txw, "foo");
 
-					tree.Add(txw, "foos/1", new MemoryStream());
+					tree.Add("foos/1", new MemoryStream());
 
 					txw.Commit();
 
@@ -74,7 +74,7 @@ namespace Voron.Tests.Bugs
 
 				Env.FlushLogToDataFile();
 
-				Assert.NotNull(Env.State.GetTree(txr, "foo").Read(txr, "foos/1"));
+				Assert.NotNull(Env.State.GetTree(txr, "foo").Read("foos/1"));
 			}
 		}
 	}

--- a/Voron.Tests/Bugs/PagesFilteredOutByJournalApplicator.cs
+++ b/Voron.Tests/Bugs/PagesFilteredOutByJournalApplicator.cs
@@ -20,7 +20,7 @@ namespace Voron.Tests.Bugs
 			{
 				var tree = Env.CreateTree(txw, "foo");
 
-				tree.Add(txw, "bars/1", new MemoryStream(bytes));
+				tree.Add("bars/1", new MemoryStream(bytes));
 
 				txw.Commit();
 
@@ -47,7 +47,7 @@ namespace Voron.Tests.Bugs
 				{
 					var tree = Env.State.GetTree(txw, "foo");
 
-					tree.Add(txw, "bars/1", new MemoryStream());
+					tree.Add("bars/1", new MemoryStream());
 
 					txw.Commit();
 
@@ -56,7 +56,7 @@ namespace Voron.Tests.Bugs
 
 				Env.FlushLogToDataFile();
 
-				Assert.NotNull(Env.State.GetTree(txr, "foo").Read(txr, "bars/1"));
+				Assert.NotNull(Env.State.GetTree(txr, "foo").Read("bars/1"));
 			}
 		} 
 
@@ -69,10 +69,10 @@ namespace Voron.Tests.Bugs
 			{
 				var tree = Env.CreateTree(txw, "foo");
 
-				tree.Add(txw, "bars/1", new MemoryStream(bytes));
-				tree.Add(txw, "bars/2", new MemoryStream(bytes));
-				tree.Add(txw, "bars/3", new MemoryStream(bytes));
-				tree.Add(txw, "bars/4", new MemoryStream(bytes));
+				tree.Add("bars/1", new MemoryStream(bytes));
+				tree.Add("bars/2", new MemoryStream(bytes));
+				tree.Add("bars/3", new MemoryStream(bytes));
+				tree.Add("bars/4", new MemoryStream(bytes));
 
 				txw.Commit();
 
@@ -83,8 +83,8 @@ namespace Voron.Tests.Bugs
 			{
 				var tree = Env.State.GetTree(txw, "foo");
 
-				tree.Add(txw, "bars/0", new MemoryStream());
-				tree.Add(txw, "bars/5", new MemoryStream());
+				tree.Add("bars/0", new MemoryStream());
+				tree.Add("bars/5", new MemoryStream());
 
 				txw.Commit();
 
@@ -111,7 +111,7 @@ namespace Voron.Tests.Bugs
 				{
 					var tree = Env.State.GetTree(txw, "foo");
 
-					tree.Add(txw, "bars/4", new MemoryStream());
+					tree.Add("bars/4", new MemoryStream());
 
 					txw.Commit();
 
@@ -120,7 +120,7 @@ namespace Voron.Tests.Bugs
 
 				Env.FlushLogToDataFile();
 
-				Assert.NotNull(Env.State.GetTree(txr, "foo").Read(txr, "bars/5"));
+				Assert.NotNull(Env.State.GetTree(txr, "foo").Read("bars/5"));
 			}
 		}
 	}

--- a/Voron.Tests/Bugs/Recovery.cs
+++ b/Voron.Tests/Bugs/Recovery.cs
@@ -44,7 +44,7 @@ namespace Voron.Tests.Bugs
 
 					for (var i = 0; i < 100; i++)
 					{
-						tree.Add(tx, "key" + i, new MemoryStream());
+						tree.Add("key" + i, new MemoryStream());
 					}
 
 					tx.Commit();
@@ -67,7 +67,7 @@ namespace Voron.Tests.Bugs
 
 					for (var i = 0; i < 100; i++)
 					{
-						Assert.NotNull(tree.Read(tx, "key" + i));
+						Assert.NotNull(tree.Read("key" + i));
 					}
 				}
 			}
@@ -95,7 +95,7 @@ namespace Voron.Tests.Bugs
 				{
 					for (var i = 0; i < 10000; i++)
 					{
-						tx.Environment.State.GetTree(tx,"tree").Add(tx, "a" + i, new MemoryStream());
+						tx.Environment.State.GetTree(tx,"tree").Add("a" + i, new MemoryStream());
 					}
 				}
 			}
@@ -127,8 +127,8 @@ namespace Voron.Tests.Bugs
 				{
 					for (var i = 0; i < 10000; i++)
 					{
-						tx.Environment.State.GetTree(tx,"atree").Add(tx, "a" + i, new MemoryStream());
-						tx.Environment.State.GetTree(tx,"btree").MultiAdd(tx, "a" + i, "a" + i);
+						tx.Environment.State.GetTree(tx,"atree").Add("a" + i, new MemoryStream());
+						tx.Environment.State.GetTree(tx,"btree").MultiAdd("a" + i, "a" + i);
 					}
 				}
 			}
@@ -155,7 +155,7 @@ namespace Voron.Tests.Bugs
 
 					for (var i = 0; i < 1000; i++)
 					{
-						tree.Add(tx, "key" + i, new MemoryStream());
+						tree.Add("key" + i, new MemoryStream());
 					}
 
 					tx.Commit();
@@ -167,7 +167,7 @@ namespace Voron.Tests.Bugs
 
 					for (var i = 0; i < 1; i++)
 					{
-						tree.Add(tx, "key" + i, new MemoryStream());
+						tree.Add("key" + i, new MemoryStream());
 					}
 
 					tx.Commit();
@@ -191,12 +191,12 @@ namespace Voron.Tests.Bugs
 
 					for (var i = 0; i < 1000; i++)
 					{
-						Assert.NotNull(aTree.Read(tx, "key" + i));
+						Assert.NotNull(aTree.Read("key" + i));
 					}
 
 					for (var i = 0; i < 1; i++)
 					{
-						Assert.NotNull(bTree.Read(tx, "key" + i));
+						Assert.NotNull(bTree.Read("key" + i));
 					}
 				}
 			}
@@ -219,7 +219,7 @@ namespace Voron.Tests.Bugs
 
 					for (var i = 0; i < 1000; i++)
 					{
-						tree.Add(tx, "key" + i, new MemoryStream());
+						tree.Add("key" + i, new MemoryStream());
 					}
 
 					tx.Commit();
@@ -231,7 +231,7 @@ namespace Voron.Tests.Bugs
 
 					for (var i = 0; i < 5; i++)
 					{
-						tree.Add(tx, "key" + i, new MemoryStream());
+						tree.Add("key" + i, new MemoryStream());
 					}
 
 					tx.Commit();
@@ -255,12 +255,12 @@ namespace Voron.Tests.Bugs
 
 					for (var i = 0; i < 1000; i++)
 					{
-						Assert.NotNull(aTree.Read(tx, "key" + i));
+						Assert.NotNull(aTree.Read("key" + i));
 					}
 
 					for (var i = 0; i < 5; i++)
 					{
-						Assert.NotNull(bTree.Read(tx, "key" + i));
+						Assert.NotNull(bTree.Read("key" + i));
 					}
 				}
 			}
@@ -298,8 +298,8 @@ namespace Voron.Tests.Bugs
 
 					for (var i = 0; i < count; i++)
 					{
-						aTree.Add(tx, "a" + i, new MemoryStream(buffer));
-						bTree.MultiAdd(tx, "a", "a" + i);
+						aTree.Add("a" + i, new MemoryStream(buffer));
+						bTree.MultiAdd("a", "a" + i);
 					}
 
 					tx.Commit();
@@ -328,12 +328,12 @@ namespace Voron.Tests.Bugs
 
 					for (var i = 0; i < count; i++)
 					{
-					    var read = aTree.Read(tx, "a" + i);
+					    var read = aTree.Read("a" + i);
 					    Assert.NotNull(read);
 					    Assert.Equal(expectedString, read.Reader.ToStringValue());
 					}
 
-				    using (var iterator = bTree.MultiRead(tx, "a"))
+				    using (var iterator = bTree.MultiRead("a"))
 					{
 						Assert.True(iterator.Seek(Slice.BeforeAllKeys));
 

--- a/Voron.Tests/Bugs/RecoveryMultipleJournals.cs
+++ b/Voron.Tests/Bugs/RecoveryMultipleJournals.cs
@@ -31,7 +31,7 @@ namespace Voron.Tests.Bugs
 			{
 				for (var i = 0; i < 1000; i++)
 				{
-					tx.Environment.State.GetTree(tx,"tree").Add(tx, "a" + i, new MemoryStream(new byte[100]));
+					tx.Environment.State.GetTree(tx,"tree").Add("a" + i, new MemoryStream(new byte[100]));
 				}
 				tx.Commit();
 			}
@@ -50,7 +50,7 @@ namespace Voron.Tests.Bugs
 			{
 				for (var i = 0; i < 1000; i++)
 				{
-					var readResult = tx.Environment.State.GetTree(tx,"tree").Read(tx, "a" + i);
+					var readResult = tx.Environment.State.GetTree(tx,"tree").Read("a" + i);
 					Assert.NotNull(readResult);
 					{
 						Assert.Equal(100, readResult.Reader.Length);
@@ -76,7 +76,7 @@ namespace Voron.Tests.Bugs
 			{
 				for (var i = 0; i < 1000; i++)
 				{
-					tx.Environment.State.GetTree(tx,"tree").Add(tx, "a" + i, new MemoryStream(new byte[100]));
+					tx.Environment.State.GetTree(tx,"tree").Add("a" + i, new MemoryStream(new byte[100]));
 				}
 				//tx.Commit(); - not committing here
 			}
@@ -85,7 +85,7 @@ namespace Voron.Tests.Bugs
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.Environment.State.GetTree(tx,"tree").Add(tx, "a", new MemoryStream(new byte[100]));
+				tx.Environment.State.GetTree(tx,"tree").Add("a", new MemoryStream(new byte[100]));
 				tx.Commit();
 			}
 
@@ -106,7 +106,7 @@ namespace Voron.Tests.Bugs
 			{
 				for (var i = 0; i < 1000; i++)
 				{
-					tx.Environment.State.GetTree(tx,"tree").Add(tx, "a" + i, new MemoryStream(new byte[100]));
+					tx.Environment.State.GetTree(tx,"tree").Add("a" + i, new MemoryStream(new byte[100]));
 				}
 				tx.Commit(); 
 			}
@@ -121,7 +121,7 @@ namespace Voron.Tests.Bugs
 			{
 				for (var i = 0; i < 1000; i++)
 				{
-					tx.Environment.State.GetTree(tx,"tree").Add(tx, "b" + i, new MemoryStream(buffer));
+					tx.Environment.State.GetTree(tx,"tree").Add("b" + i, new MemoryStream(buffer));
 				}
 				//tx.Commit(); - not committing here
 			}
@@ -130,7 +130,7 @@ namespace Voron.Tests.Bugs
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.Environment.State.GetTree(tx,"tree").Add(tx, "b", new MemoryStream(buffer));
+				tx.Environment.State.GetTree(tx,"tree").Add("b", new MemoryStream(buffer));
 				tx.Commit();
 			}
 
@@ -143,7 +143,7 @@ namespace Voron.Tests.Bugs
 		    RequireFileBasedPager();
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				Env.CreateTree(tx, "tree").Add(tx, "exists", new MemoryStream(new byte[100]));
+				Env.CreateTree(tx, "tree").Add("exists", new MemoryStream(new byte[100]));
 
 				tx.Commit();
 			}
@@ -152,7 +152,7 @@ namespace Voron.Tests.Bugs
 			{
 				for (var i = 0; i < 1000; i++)
 				{
-					tx.Environment.State.GetTree(tx,"tree").Add(tx, "a" + i, new MemoryStream(new byte[100]));
+					tx.Environment.State.GetTree(tx,"tree").Add("a" + i, new MemoryStream(new byte[100]));
 				}
 				tx.Commit();
 			}
@@ -167,11 +167,11 @@ namespace Voron.Tests.Bugs
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
                 var tree = Env.CreateTree(tx, "tree");
-                Assert.NotNull(tree.Read(tx, "exists"));
-                Assert.Null(tree.Read(tx, "a1"));
-                Assert.Null(tree.Read(tx, "a100"));
-                Assert.Null(tree.Read(tx, "a500"));
-                Assert.Null(tree.Read(tx, "a1000"));
+                Assert.NotNull(tree.Read("exists"));
+                Assert.Null(tree.Read("a1"));
+                Assert.Null(tree.Read("a100"));
+                Assert.Null(tree.Read("a500"));
+                Assert.Null(tree.Read("a1000"));
                 
                 tx.Commit();
             }
@@ -192,7 +192,7 @@ namespace Voron.Tests.Bugs
 			{
 				for (var i = 0; i < 1000; i++)
 				{
-					tx.Environment.State.GetTree(tx,"tree").Add(tx, "a" + i, new MemoryStream(new byte[100]));
+					tx.Environment.State.GetTree(tx,"tree").Add("a" + i, new MemoryStream(new byte[100]));
 				}
 				tx.Commit();
 			}
@@ -203,7 +203,7 @@ namespace Voron.Tests.Bugs
 			{
 				for (var i = 0; i < 1000; i++)
 				{
-					tx.Environment.State.GetTree(tx,"tree").Add(tx, "b" + i, new MemoryStream(new byte[100]));
+					tx.Environment.State.GetTree(tx,"tree").Add("b" + i, new MemoryStream(new byte[100]));
 				}
 				tx.Commit();
 			}
@@ -235,7 +235,7 @@ namespace Voron.Tests.Bugs
 			{
 				using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 				{
-					tx.Environment.State.GetTree(tx,"tree").Add(tx, "a" + i, new MemoryStream(new byte[100]));
+					tx.Environment.State.GetTree(tx,"tree").Add("a" + i, new MemoryStream(new byte[100]));
 					tx.Commit();
 				}
 			}
@@ -258,7 +258,7 @@ namespace Voron.Tests.Bugs
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				Assert.Null(tx.Environment.State.GetTree(tx,"tree").Read(tx, "a999"));
+				Assert.Null(tx.Environment.State.GetTree(tx,"tree").Read("a999"));
 			}
 
 		}

--- a/Voron.Tests/Bugs/RecoveryWithManualFlush.cs
+++ b/Voron.Tests/Bugs/RecoveryWithManualFlush.cs
@@ -21,8 +21,8 @@ namespace Voron.Tests.Bugs
         {
             using (var tx1 = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                tx1.State.Root.Add(tx1, "item/1", new MemoryStream(new byte[4000]));
-                tx1.State.Root.Add(tx1, "item/2", new MemoryStream(new byte[4000]));
+                tx1.State.Root.Add("item/1", new MemoryStream(new byte[4000]));
+                tx1.State.Root.Add("item/2", new MemoryStream(new byte[4000]));
 
                 tx1.Commit();
             }
@@ -33,7 +33,7 @@ namespace Voron.Tests.Bugs
 
                 // this will also override the page translation table for the page where item/2 is placed
 
-                tx2.State.Root.Add(tx2, "item/2", new MemoryStream(new byte[3999]));
+                tx2.State.Root.Add("item/2", new MemoryStream(new byte[3999]));
 
                 tx2.Commit();
             }
@@ -57,12 +57,12 @@ namespace Voron.Tests.Bugs
 
             using (var tx = Env.NewTransaction(TransactionFlags.Read))
             {
-                var readResult = tx.State.Root.Read(tx, "item/1");
+                var readResult = tx.State.Root.Read("item/1");
 
                 Assert.NotNull(readResult);
                 Assert.Equal(4000, readResult.Reader.Length);
 
-                readResult = tx.State.Root.Read(tx, "item/2");
+                readResult = tx.State.Root.Read("item/2");
 
                 Assert.NotNull(readResult);
                 Assert.Equal(3999, readResult.Reader.Length);
@@ -74,15 +74,15 @@ namespace Voron.Tests.Bugs
         {
             using (var tx1 = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                tx1.State.Root.Add(tx1, "item/1", new MemoryStream(new byte[4000]));
-                tx1.State.Root.Add(tx1, "item/2", new MemoryStream(new byte[4000]));
+                tx1.State.Root.Add("item/1", new MemoryStream(new byte[4000]));
+                tx1.State.Root.Add("item/2", new MemoryStream(new byte[4000]));
 
                 tx1.Commit();
             }
 
             using (var tx2 = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                tx2.State.Root.Add(tx2, "item/2", new MemoryStream(new byte[3999]));
+                tx2.State.Root.Add("item/2", new MemoryStream(new byte[3999]));
 
                 tx2.Commit();
             }
@@ -100,12 +100,12 @@ namespace Voron.Tests.Bugs
 
             using (var tx = Env.NewTransaction(TransactionFlags.Read))
             {
-                var readResult = tx.State.Root.Read(tx, "item/1");
+                var readResult = tx.State.Root.Read("item/1");
 
                 Assert.NotNull(readResult);
                 Assert.Equal(4000, readResult.Reader.Length);
 
-                readResult = tx.State.Root.Read(tx, "item/2");
+                readResult = tx.State.Root.Read("item/2");
 
                 Assert.NotNull(readResult);
                 Assert.Equal(3999, readResult.Reader.Length);
@@ -117,7 +117,7 @@ namespace Voron.Tests.Bugs
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "items/1", new MemoryStream(new byte[] { 1, 2, 3 }));
+				tx.State.Root.Add("items/1", new MemoryStream(new byte[] { 1, 2, 3 }));
 				tx.Commit();
 			}
 
@@ -127,7 +127,7 @@ namespace Voron.Tests.Bugs
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var readResult = tx.State.Root.Read(tx, "items/1");
+				var readResult = tx.State.Root.Read("items/1");
 
 				Assert.NotNull(readResult);
 				Assert.Equal(3, readResult.Reader.Length);

--- a/Voron.Tests/Bugs/RequiredPrefixWithSeekBeforeAllKeys.cs
+++ b/Voron.Tests/Bugs/RequiredPrefixWithSeekBeforeAllKeys.cs
@@ -1,0 +1,65 @@
+﻿using Voron.Impl;
+using Xunit;
+
+namespace Voron.Tests.Bugs
+{ 
+	public class RequiredPrefixWithSeekBeforeAllKeys : StorageTest
+	{
+		[Fact]
+		public void SeekBeforeAllKeys_with_required_prefix_should_return_true_if_relevant_nodes_exist()
+		{
+			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				Env.CreateTree(tx, "testTree");
+				tx.Commit();
+			}
+
+			var wb = new WriteBatch();
+			wb.Add("AA", StreamFor("Foo1"), "testTree");
+			wb.Add("AB", StreamFor("Foo2"), "testTree");
+
+			wb.Add("ACA", StreamFor("Foo3"), "testTree");
+			wb.Add("ACB", StreamFor("Foo4"), "testTree");
+			wb.Add("ACC", StreamFor("Foo5"), "testTree");
+
+			wb.Add("ADA", StreamFor("Foo6"), "testTree");
+			wb.Add("ADB", StreamFor("Foo7"), "testTree");
+
+			Env.Writer.Write(wb);
+
+			using(var snapshot = Env.CreateSnapshot())
+			using (var iterator = snapshot.Iterate("testTree"))
+			{
+				iterator.RequiredPrefix = "AC";
+				Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+			}
+		}
+
+
+		[Fact]
+		public void SeekBeforeAllKeys_with_required_prefix_should_return_false_if_relevant_nodes_doesnt_exist()
+		{
+			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				Env.CreateTree(tx, "testTree");
+				tx.Commit();
+			}
+
+			var wb = new WriteBatch();
+			wb.Add("AA", StreamFor("Foo1"), "testTree");
+			wb.Add("AB", StreamFor("Foo2"), "testTree");
+
+			wb.Add("ADA", StreamFor("Foo6"), "testTree");
+			wb.Add("ADB", StreamFor("Foo7"), "testTree");
+
+			Env.Writer.Write(wb);
+
+			using (var snapshot = Env.CreateSnapshot())
+			using (var iterator = snapshot.Iterate("testTree"))
+			{
+				iterator.RequiredPrefix = "AC";
+				Assert.False(iterator.Seek(Slice.BeforeAllKeys));
+			}
+		}
+	}
+}

--- a/Voron.Tests/Bugs/Snapshots.cs
+++ b/Voron.Tests/Bugs/Snapshots.cs
@@ -1,4 +1,5 @@
-﻿using Voron.Debugging;
+﻿using System.Linq;
+using Voron.Debugging;
 
 namespace Voron.Tests.Bugs
 {
@@ -68,7 +69,8 @@ namespace Voron.Tests.Bugs
 					Assert.NotNull(result);
 
 					{
-                        Assert.Equal(testBuffer, result.Reader.ReadBytes(result.Reader.Length));
+						int used;
+						Assert.Equal(testBuffer, result.Reader.ReadBytes(result.Reader.Length, out used).Take(used).ToArray());
 					}
 				}
 			}
@@ -125,7 +127,8 @@ namespace Voron.Tests.Bugs
 					Assert.NotNull(result);
 
 					{
-						Assert.Equal(testBuffer, result.Reader.ReadBytes(result.Reader.Length));
+						int used;
+						Assert.Equal(testBuffer, result.Reader.ReadBytes(result.Reader.Length, out used).Take(used).ToArray());
 					}
 				}
 			}

--- a/Voron.Tests/Bugs/Snapshots.cs
+++ b/Voron.Tests/Bugs/Snapshots.cs
@@ -44,7 +44,7 @@ namespace Voron.Tests.Bugs
 			    var t1 = tx.Environment.State.GetTree(tx,"tree1");
 				for (var i = 0; i < DocumentCount; i++)
 				{
-					t1.Add(tx, "docs/" + i, new MemoryStream(testBuffer));
+					t1.Add("docs/" + i, new MemoryStream(testBuffer));
 				}
 
 				tx.Commit();
@@ -57,7 +57,7 @@ namespace Voron.Tests.Bugs
 				    var t1 = tx.Environment.State.GetTree(tx,"tree1");
 					for (var i = 0; i < DocumentCount; i++)
 					{
-						t1.Delete(tx, "docs/" + i);
+						t1.Delete("docs/" + i);
 					}
 
 					tx.Commit();
@@ -98,7 +98,7 @@ namespace Voron.Tests.Bugs
 				var t1 = tx.Environment.State.GetTree(tx, "tree1");
 				for (var i = 0; i < DocumentCount; i++)
 				{
-					t1.Add(tx, "docs/" + i, new MemoryStream(testBuffer));
+					t1.Add("docs/" + i, new MemoryStream(testBuffer));
 				}
 
 				tx.Commit();
@@ -113,7 +113,7 @@ namespace Voron.Tests.Bugs
 					var t1 = tx.Environment.State.GetTree(tx, "tree1");
 					for (var i = 0; i < DocumentCount; i++)
 					{
-						t1.Delete(tx, "docs/" + i);
+						t1.Delete("docs/" + i);
 					}
 
 					tx.Commit();

--- a/Voron.Tests/Bugs/TreeRebalancer.cs
+++ b/Voron.Tests/Bugs/TreeRebalancer.cs
@@ -27,14 +27,14 @@ namespace Voron.Tests.Bugs
 
 							addedIds.Add("test/0/user-" + i, id);
 
-							multiTree.MultiAdd(tx, "test/0/user-" + i, id);
+							multiTree.MultiAdd("test/0/user-" + i, id);
 						}
 					}
 
 					foreach (var multiTreeName in multiTrees)
 					{
                         var multiTree = tx.Environment.State.GetTree(tx,multiTreeName);
-						multiTree.MultiAdd(tx, "test/0/user-50", Guid.NewGuid().ToString());
+						multiTree.MultiAdd("test/0/user-50", Guid.NewGuid().ToString());
 					}
 
 					tx.Commit();
@@ -49,7 +49,7 @@ namespace Voron.Tests.Bugs
                         {
                             var multiTree = tx.Environment.State.GetTree(tx,multiTreeName);
 					
-							multiTree.MultiDelete(tx, "test/0/user-" + i, addedIds["test/0/user-" + i]);
+							multiTree.MultiDelete("test/0/user-" + i, addedIds["test/0/user-" + i]);
 						}
 
 						tx.Commit();
@@ -70,7 +70,7 @@ namespace Voron.Tests.Bugs
                         {
                             var multiTree = tx.Environment.State.GetTree(tx,multiTreeName);
 					
-							multiTree.MultiDelete(tx, "test/0/user-" + i, addedIds["test/0/user-" + i]);
+							multiTree.MultiDelete("test/0/user-" + i, addedIds["test/0/user-" + i]);
 						}
 
 						tx.Commit();
@@ -126,12 +126,12 @@ namespace Voron.Tests.Bugs
 				var eKey = new string('e', 600);
 				var fKey = new string('f', 920);
 
-				tree.Add(tx, aKey, new MemoryStream(new byte[1000]));
-				tree.Add(tx, bKey, new MemoryStream(new byte[1000]));
-				tree.Add(tx, cKey, new MemoryStream(new byte[1000]));
-				tree.Add(tx, dKey, new MemoryStream(new byte[1000]));
-				tree.Add(tx, eKey, new MemoryStream(new byte[800]));
-				tree.Add(tx, fKey, new MemoryStream(new byte[10]));
+				tree.Add(aKey, new MemoryStream(new byte[1000]));
+				tree.Add(bKey, new MemoryStream(new byte[1000]));
+				tree.Add(cKey, new MemoryStream(new byte[1000]));
+				tree.Add(dKey, new MemoryStream(new byte[1000]));
+				tree.Add(eKey, new MemoryStream(new byte[800]));
+				tree.Add(fKey, new MemoryStream(new byte[10]));
 
 				RenderAndShow(tx, 1, "rebalancing-issue");
 
@@ -139,11 +139,11 @@ namespace Voron.Tests.Bugs
 				// tree rebalance will try to fix the first reference (the implicit ref page node) in the parent page which is almost full 
 				// and will fail because there is no space to put a new node
 
-				tree.Delete(tx, aKey); // this line throws "The page is full and cannot add an entry, this is probably a bug"
+				tree.Delete(aKey); // this line throws "The page is full and cannot add an entry, this is probably a bug"
 
 				tx.Commit();
 
-				using (var iterator = tree.Iterate(tx))
+				using (var iterator = tree.Iterate())
 				{
 					Assert.True(iterator.Seek(Slice.BeforeAllKeys));
 

--- a/Voron.Tests/Bugs/UpdateLastItem.cs
+++ b/Voron.Tests/Bugs/UpdateLastItem.cs
@@ -12,14 +12,14 @@ namespace Voron.Tests.Bugs
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.DirectAdd(tx, "events", sizeof (TreeRootHeader));
-				tx.State.Root.DirectAdd(tx, "aggregations", sizeof (TreeRootHeader));
-				tx.State.Root.DirectAdd(tx, "aggregation-status", sizeof (TreeRootHeader));
+				tx.State.Root.DirectAdd("events", sizeof (TreeRootHeader));
+				tx.State.Root.DirectAdd("aggregations", sizeof (TreeRootHeader));
+				tx.State.Root.DirectAdd("aggregation-status", sizeof (TreeRootHeader));
 				tx.Commit();
 			}
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.DirectAdd(tx, "events", sizeof (TreeRootHeader));
+				tx.State.Root.DirectAdd("events", sizeof (TreeRootHeader));
 
 				tx.Commit();
 			}
@@ -28,7 +28,7 @@ namespace Voron.Tests.Bugs
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.DirectAdd(tx, "events", sizeof (TreeRootHeader));
+				tx.State.Root.DirectAdd("events", sizeof (TreeRootHeader));
 
 				tx.Commit();
 			}

--- a/Voron.Tests/Journal/BasicActions.cs
+++ b/Voron.Tests/Journal/BasicActions.cs
@@ -31,7 +31,7 @@ namespace Voron.Tests.Journal
             {
                 using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
                 {
-                    tx.State.Root.Add(tx, "item/" + i, new MemoryStream(bytes));
+                    tx.State.Root.Add("item/" + i, new MemoryStream(bytes));
                     tx.Commit();
                 }
             }
@@ -42,7 +42,7 @@ namespace Voron.Tests.Journal
             {
                 using (var tx = Env.NewTransaction(TransactionFlags.Read))
                 {
-                    Assert.NotNull(tx.State.Root.Read(tx, "item/" + i));
+                    Assert.NotNull(tx.State.Root.Read("item/" + i));
                 }
             }
         }
@@ -52,13 +52,13 @@ namespace Voron.Tests.Journal
         {
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                tx.State.Root.Add(tx, "items/1", StreamFor("values/1"));
+                tx.State.Root.Add("items/1", StreamFor("values/1"));
                 // tx.Commit(); uncommitted transaction
             }
 
             using (var tx = Env.NewTransaction(TransactionFlags.Read))
             {
-                Assert.Null(tx.State.Root.Read(tx, "items/1"));
+                Assert.Null(tx.State.Root.Read("items/1"));
             }
         }
 
@@ -70,7 +70,7 @@ namespace Voron.Tests.Journal
                
                 using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
                 {
-                    tx.State.Root.Add(tx, "items/" + i, StreamFor("values/" + i));
+                    tx.State.Root.Add("items/" + i, StreamFor("values/" + i));
                     tx.Commit();
                 }
             }

--- a/Voron.Tests/Journal/EdgeCases.cs
+++ b/Voron.Tests/Journal/EdgeCases.cs
@@ -25,28 +25,28 @@ namespace Voron.Tests.Journal
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
 				var bytes = new byte[4 * AbstractPager.PageSize]; 
-				tx.State.Root.Add(tx, "items/0", new MemoryStream(bytes));
+				tx.State.Root.Add("items/0", new MemoryStream(bytes));
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
 				var bytes = new byte[1 * AbstractPager.PageSize];
-				tx.State.Root.Add(tx, "items/1", new MemoryStream(bytes));
+				tx.State.Root.Add("items/1", new MemoryStream(bytes));
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
 				var bytes = new byte[1 * AbstractPager.PageSize];
-				tx.State.Root.Add(tx, "items/1", new MemoryStream(bytes));
+				tx.State.Root.Add("items/1", new MemoryStream(bytes));
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
 				var bytes = new byte[1 * AbstractPager.PageSize];
-				tx.State.Root.Add(tx, "items/1", new MemoryStream(bytes));
+				tx.State.Root.Add("items/1", new MemoryStream(bytes));
 				tx.Commit();
 			}
 

--- a/Voron.Tests/Journal/Mvcc.cs
+++ b/Voron.Tests/Journal/Mvcc.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System.IO;
+using System.Linq;
 using Voron.Impl;
 using Voron.Impl.Paging;
 using Xunit;
@@ -52,7 +53,8 @@ namespace Voron.Tests.Journal
 
 				var readResult = txr.State.Root.Read(txr, "items/1");
 
-			    var readData = readResult.Reader.ReadBytes(readResult.Reader.Length);
+				int used;
+				var readData = readResult.Reader.ReadBytes(readResult.Reader.Length, out used).Take(used).ToArray();
 
 				for (int i = 0; i < 3000; i++)
 				{

--- a/Voron.Tests/Journal/Mvcc.cs
+++ b/Voron.Tests/Journal/Mvcc.cs
@@ -34,8 +34,8 @@ namespace Voron.Tests.Journal
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "items/1", new MemoryStream(ones));
-				tx.State.Root.Add(tx, "items/2", new MemoryStream(ones));
+				tx.State.Root.Add("items/1", new MemoryStream(ones));
+				tx.State.Root.Add("items/2", new MemoryStream(ones));
 				tx.Commit();
 			}
 
@@ -45,13 +45,13 @@ namespace Voron.Tests.Journal
 			{
 				using (var txw = Env.NewTransaction(TransactionFlags.ReadWrite))
 				{
-					txw.State.Root.Add(txw, "items/1", new MemoryStream(nines));
+					txw.State.Root.Add("items/1", new MemoryStream(nines));
 					txw.Commit();
 				}
 
 				Env.FlushLogToDataFile(); // should not flush pages of items/1 because there is an active read transaction
 
-				var readResult = txr.State.Root.Read(txr, "items/1");
+				var readResult = txr.State.Root.Read("items/1");
 
 				int used;
 				var readData = readResult.Reader.ReadBytes(readResult.Reader.Length, out used).Take(used).ToArray();

--- a/Voron.Tests/Journal/UncommittedTransactions.cs
+++ b/Voron.Tests/Journal/UncommittedTransactions.cs
@@ -38,7 +38,7 @@ namespace Voron.Tests.Journal
 			using (var tx2 = Env.NewTransaction(TransactionFlags.Read))
 			{
 				// tx was not committed so in the log should not apply
-				var readPage = Env.Journal.ReadPage(tx2,pageAllocatedInUncommittedTransaction);
+				var readPage = Env.Journal.ReadPage(tx2,pageAllocatedInUncommittedTransaction, scratchPagerState: null);
 
 				Assert.Null(readPage);
 			}

--- a/Voron.Tests/MultiTreeSize.cs
+++ b/Voron.Tests/MultiTreeSize.cs
@@ -1,0 +1,43 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MultiTreeSize.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using Voron.Impl.Paging;
+using Xunit;
+
+namespace Voron.Tests
+{
+	public class MultiTreeSize : StorageTest
+	{
+		[Fact]
+		public void Single_AddMulti_WillUseOnePage()
+		{
+			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				tx.State.Root.MultiAdd(tx, "ChildTreeKey", "test");
+				tx.Commit();
+			}
+
+			Assert.Equal(AbstractPager.PageSize,
+				Env.Stats().UsedDataFileSizeInBytes
+			);
+		}
+
+		[Fact]
+		public void TwoSmall_AddMulti_WillUseOnePage()
+		{
+			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				tx.State.Root.MultiAdd(tx, "ChildTreeKey", "test1");
+				tx.State.Root.MultiAdd(tx, "ChildTreeKey", "test2");
+				tx.Commit();
+			}
+
+			Assert.Equal(AbstractPager.PageSize,
+				Env.Stats().UsedDataFileSizeInBytes
+			);
+		}
+	}
+}

--- a/Voron.Tests/MultiTreeSize.cs
+++ b/Voron.Tests/MultiTreeSize.cs
@@ -16,7 +16,7 @@ namespace Voron.Tests
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.MultiAdd(tx, "ChildTreeKey", "test");
+				tx.State.Root.MultiAdd("ChildTreeKey", "test");
 				tx.Commit();
 			}
 
@@ -30,8 +30,8 @@ namespace Voron.Tests
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.MultiAdd(tx, "ChildTreeKey", "test1");
-				tx.State.Root.MultiAdd(tx, "ChildTreeKey", "test2");
+				tx.State.Root.MultiAdd("ChildTreeKey", "test1");
+				tx.State.Root.MultiAdd("ChildTreeKey", "test2");
 				tx.Commit();
 			}
 

--- a/Voron.Tests/MultiValueTree.cs
+++ b/Voron.Tests/MultiValueTree.cs
@@ -27,13 +27,13 @@ namespace Voron.Tests
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.Environment.State.GetTree(tx,"foo").MultiAdd(tx, "ChildTreeKey", new Slice(buffer));
+				tx.Environment.State.GetTree(tx,"foo").MultiAdd("ChildTreeKey", new Slice(buffer));
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				using (var fetchedDataIterator = tx.Environment.State.GetTree(tx,"foo").MultiRead(tx, "ChildTreeKey"))
+				using (var fetchedDataIterator = tx.Environment.State.GetTree(tx,"foo").MultiRead("ChildTreeKey"))
 				{
 					fetchedDataIterator.Seek(Slice.BeforeAllKeys);
 
@@ -59,7 +59,7 @@ namespace Voron.Tests
 		    {
 		        for (int i = 0; i < INPUT_COUNT; i++)
 		        {
-		            tx.State.Root.MultiAdd(tx, CHILDTREE_KEY, inputData[i]);
+		            tx.State.Root.MultiAdd(CHILDTREE_KEY, inputData[i]);
 		        }
 		        tx.Commit();
 		    }
@@ -68,7 +68,7 @@ namespace Voron.Tests
 		    {
 		        for (int i = 0; i < INPUT_COUNT - 1; i++)
 		        {
-		            tx.State.Root.MultiDelete(tx, CHILDTREE_KEY, inputData[i]);
+		            tx.State.Root.MultiDelete(CHILDTREE_KEY, inputData[i]);
 		            inputData.Remove(inputData[i]);
 		        }
 		        tx.Commit();
@@ -94,7 +94,7 @@ namespace Voron.Tests
 			{
 				for (int i = 0; i < INPUT_COUNT; i++)
 				{
-                    tx.State.Root.MultiAdd(tx, CHILDTREE_KEY, inputData[i]);
+                    tx.State.Root.MultiAdd(CHILDTREE_KEY, inputData[i]);
 				}
 				tx.Commit();
 			}
@@ -103,14 +103,14 @@ namespace Voron.Tests
 			{
 				for (int i = 0; i < INPUT_COUNT; i++)
 				{
-                    tx.State.Root.MultiDelete(tx, CHILDTREE_KEY, inputData[i]);
+                    tx.State.Root.MultiDelete(CHILDTREE_KEY, inputData[i]);
 				}
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var iterator = tx.State.Root.MultiRead(tx, CHILDTREE_KEY);
+				var iterator = tx.State.Root.MultiRead(CHILDTREE_KEY);
 				iterator.Seek(Slice.BeforeAllKeys);
 				Assert.False(iterator.MoveNext());
 			}
@@ -131,19 +131,19 @@ namespace Voron.Tests
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.Environment.State.GetTree(tx,"foo").MultiAdd(tx, "ChildTreeKey", new Slice(buffer));
+				tx.Environment.State.GetTree(tx,"foo").MultiAdd("ChildTreeKey", new Slice(buffer));
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.Environment.State.GetTree(tx,"foo").MultiDelete(tx, "ChildTreeKey", new Slice(buffer));
+				tx.Environment.State.GetTree(tx,"foo").MultiDelete("ChildTreeKey", new Slice(buffer));
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				Assert.Equal(typeof(EmptyIterator), tx.Environment.State.GetTree(tx,"foo").MultiRead(tx, "ChildTreeKey").GetType());
+				Assert.Equal(typeof(EmptyIterator), tx.Environment.State.GetTree(tx,"foo").MultiRead("ChildTreeKey").GetType());
 			}
 		}
 
@@ -165,10 +165,10 @@ namespace Voron.Tests
 		    {
 		        for (int i = 0; i < INPUT_COUNT; i++)
 		        {
-		            tx.State.Root.MultiAdd(tx, CHILDTREE_KEY, inputData[i]);
+		            tx.State.Root.MultiAdd(CHILDTREE_KEY, inputData[i]);
 		        }
 
-		        tx.State.Root.MultiDelete(tx, CHILDTREE_KEY, inputData[indexToDelete]);
+		        tx.State.Root.MultiDelete(CHILDTREE_KEY, inputData[indexToDelete]);
 		        tx.Commit();
 		    }
 
@@ -200,10 +200,10 @@ namespace Voron.Tests
 			{
 				for (int i = 0; i < INPUT_COUNT; i++)
 				{
-					tx.Environment.State.GetTree(tx,"foo").MultiAdd(tx, CHILDTREE_KEY, inputData[i]);
+					tx.Environment.State.GetTree(tx,"foo").MultiAdd(CHILDTREE_KEY, inputData[i]);
 				}
 
-				tx.Environment.State.GetTree(tx,"foo").MultiDelete(tx, CHILDTREE_KEY, inputData[indexToDelete]);
+				tx.Environment.State.GetTree(tx,"foo").MultiDelete(CHILDTREE_KEY, inputData[indexToDelete]);
 				tx.Commit();
 			}
 
@@ -235,7 +235,7 @@ namespace Voron.Tests
 			{
 				for (int i = 0; i < INPUT_COUNT; i++)
 				{
-					tx.Environment.State.GetTree(tx,"foo").MultiAdd(tx, CHILDTREE_KEY, inputData[i]);
+					tx.Environment.State.GetTree(tx,"foo").MultiAdd(CHILDTREE_KEY, inputData[i]);
 				}
 				tx.Commit();
 			}
@@ -244,7 +244,7 @@ namespace Voron.Tests
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.Environment.State.GetTree(tx,"foo").MultiDelete(tx, CHILDTREE_KEY, inputData[indexToDelete]);
+				tx.Environment.State.GetTree(tx,"foo").MultiDelete(CHILDTREE_KEY, inputData[indexToDelete]);
 				tx.Commit();
 			}
 
@@ -260,20 +260,20 @@ namespace Voron.Tests
 			const string CHILDTREE_VALUE = "Foo";
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.MultiAdd(tx, CHILDTREE_KEY, CHILDTREE_VALUE);
-				tx.State.Root.MultiAdd(tx, CHILDTREE_KEY, CHILDTREE_VALUE);
+				tx.State.Root.MultiAdd(CHILDTREE_KEY, CHILDTREE_VALUE);
+				tx.State.Root.MultiAdd(CHILDTREE_KEY, CHILDTREE_VALUE);
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				Assert.DoesNotThrow(() => tx.State.Root.MultiDelete(tx, CHILDTREE_KEY, CHILDTREE_VALUE));
+				Assert.DoesNotThrow(() => tx.State.Root.MultiDelete(CHILDTREE_KEY, CHILDTREE_VALUE));
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				Assert.Equal(0, tx.State.Root.ReadVersion(tx, CHILDTREE_KEY));
+				Assert.Equal(0, tx.State.Root.ReadVersion(CHILDTREE_KEY));
 			}
 		}
 		
@@ -294,7 +294,7 @@ namespace Voron.Tests
 			{
 				for (int i = 0; i < INPUT_COUNT; i++)
 				{
-					tx.State.Root.MultiAdd(tx, CHILDTREE_KEY, inputData[i]);
+					tx.State.Root.MultiAdd(CHILDTREE_KEY, inputData[i]);
 				}
 				tx.Commit();
 			}
@@ -305,7 +305,7 @@ namespace Voron.Tests
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.MultiDelete(tx, CHILDTREE_KEY, inputData[indexToDelete]);
+				tx.State.Root.MultiDelete(CHILDTREE_KEY, inputData[indexToDelete]);
 				tx.Commit();
 			}
 
@@ -331,7 +331,7 @@ namespace Voron.Tests
 			{
 				for (int i = 0; i < INPUT_COUNT; i++)
 				{
-					tx.State.Root.MultiAdd(tx, CHILDTREE_KEY, inputData[i]);
+					tx.State.Root.MultiAdd(CHILDTREE_KEY, inputData[i]);
 				}
 				tx.Commit();
 			}
@@ -347,7 +347,7 @@ namespace Voron.Tests
 
 				int fetchedEntryCount = 0;
 				var inputEntryCount = inputData.Count;
-				using (var fetchedDataIterator = targetTree.MultiRead(tx, childtreeKey))
+				using (var fetchedDataIterator = targetTree.MultiRead(childtreeKey))
 				{
 					fetchedDataIterator.Seek(Slice.BeforeAllKeys);
 					do

--- a/Voron.Tests/Optimizations/Writes.cs
+++ b/Voron.Tests/Optimizations/Writes.cs
@@ -17,25 +17,25 @@ namespace Voron.Tests.Optimizations
 		    var keySize = 1024;
 		    using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, new string('9', keySize), new MemoryStream(new byte[3]));
+				tx.State.Root.Add(new string('9', keySize), new MemoryStream(new byte[3]));
 				RenderAndShow(tx, tx.State.Root, 1);
-				tx.State.Root.Add(tx, new string('1', keySize), new MemoryStream(new byte[3]));
+				tx.State.Root.Add(new string('1', keySize), new MemoryStream(new byte[3]));
 				RenderAndShow(tx, tx.State.Root, 1);
-				tx.State.Root.Add(tx, new string('4', 1000), new MemoryStream(new byte[2]));
+				tx.State.Root.Add(new string('4', 1000), new MemoryStream(new byte[2]));
 				RenderAndShow(tx, tx.State.Root, 1);
-				tx.State.Root.Add(tx, new string('5', keySize), new MemoryStream(new byte[2]));
+				tx.State.Root.Add(new string('5', keySize), new MemoryStream(new byte[2]));
 				RenderAndShow(tx, tx.State.Root, 1);
-				tx.State.Root.Add(tx, new string('8', keySize), new MemoryStream(new byte[3]));
+				tx.State.Root.Add(new string('8', keySize), new MemoryStream(new byte[3]));
 				RenderAndShow(tx, tx.State.Root, 1);
-				tx.State.Root.Add(tx, new string('2', keySize), new MemoryStream(new byte[2]));
+				tx.State.Root.Add(new string('2', keySize), new MemoryStream(new byte[2]));
 				RenderAndShow(tx, tx.State.Root, 1);
-				tx.State.Root.Add(tx, new string('6', keySize), new MemoryStream(new byte[2]));
+				tx.State.Root.Add(new string('6', keySize), new MemoryStream(new byte[2]));
 				RenderAndShow(tx, tx.State.Root, 1);
-				tx.State.Root.Add(tx, new string('0', keySize), new MemoryStream(new byte[4]));
+				tx.State.Root.Add(new string('0', keySize), new MemoryStream(new byte[4]));
 				RenderAndShow(tx, tx.State.Root, 1);
-				tx.State.Root.Add(tx, new string('3', 1000), new MemoryStream(new byte[1]));
+				tx.State.Root.Add(new string('3', 1000), new MemoryStream(new byte[1]));
 				RenderAndShow(tx, tx.State.Root, 1);
-				tx.State.Root.Add(tx, new string('7', keySize), new MemoryStream(new byte[1]));
+				tx.State.Root.Add(new string('7', keySize), new MemoryStream(new byte[1]));
 				
 				tx.Commit();
 			}
@@ -44,9 +44,9 @@ namespace Voron.Tests.Optimizations
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Delete(tx, new string('0', keySize));
+				tx.State.Root.Delete(new string('0', keySize));
 
-				tx.State.Root.Add(tx, new string('4', 1000), new MemoryStream(new byte[21]));
+				tx.State.Root.Add(new string('4', 1000), new MemoryStream(new byte[21]));
 
 				tx.Commit();
 			}
@@ -56,9 +56,9 @@ namespace Voron.Tests.Optimizations
 			// ensure changes were applied
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				Assert.Null(tx.State.Root.Read(tx, new string('0', keySize)));
+				Assert.Null(tx.State.Root.Read(new string('0', keySize)));
 
-				var readResult = tx.State.Root.Read(tx, new string('4', 1000));
+				var readResult = tx.State.Root.Read(new string('4', 1000));
 
 				Assert.Equal(21, readResult.Reader.Length);
 			}

--- a/Voron.Tests/Storage/Batches.cs
+++ b/Voron.Tests/Storage/Batches.cs
@@ -353,7 +353,7 @@
             batch1.Add("key/1", new MemoryStream(Encoding.UTF8.GetBytes("tree1")), "tree1");
 
             var batch2 = new WriteBatch();
-            batch2.Add("key/1", new MemoryStream(Encoding.UTF8.GetBytes("tree2")), "tree2");
+            batch2.Add("key/1", new MemoryStream(Encoding.UTF8.GetBytes("tree2")), "tree2", version: 1);
 
             var batch3 = new WriteBatch();
             batch3.Add("key/1", new MemoryStream(Encoding.UTF8.GetBytes("tree3")), "tree3");
@@ -374,7 +374,7 @@
             }
             catch (AggregateException e)
             {
-                Assert.Equal("No such tree: tree2", e.InnerException.Message);
+				Assert.Equal("Cannot add 'key/1' to 'tree2' tree. Version mismatch. Expected: 1. Actual: 0.", e.InnerException.Message);
 
                 using (var tx = Env.NewTransaction(TransactionFlags.Read))
                 {
@@ -393,7 +393,7 @@
             batch1.Add("key/1", new MemoryStream(Encoding.UTF8.GetBytes("tree1")), "tree1");
 
             var batch2 = new WriteBatch();
-            batch2.Add("key/1", new MemoryStream(Encoding.UTF8.GetBytes("tree2")), "tree2");
+            batch2.Add("key/1", new MemoryStream(Encoding.UTF8.GetBytes("tree2")), "tree2", version: 1);
 
             var batch3 = new WriteBatch();
             batch3.Add("key/1", new MemoryStream(Encoding.UTF8.GetBytes("tree3")), "tree3");
@@ -424,7 +424,7 @@
             }
             catch (AggregateException e)
             {
-                Assert.Equal("No such tree: tree2", e.InnerException.Message);
+				Assert.Equal("Cannot add 'key/1' to 'tree2' tree. Version mismatch. Expected: 1. Actual: 0.", e.InnerException.Message);
             }
 
             using (var tx = Env.NewTransaction(TransactionFlags.Read))

--- a/Voron.Tests/Storage/Batches.cs
+++ b/Voron.Tests/Storage/Batches.cs
@@ -19,7 +19,7 @@
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
                 Env.CreateTree(tx, "tree");
-                tx.Environment.State.GetTree(tx,"tree").Add(tx, "foo1", StreamFor("foo1"));
+                tx.Environment.State.GetTree(tx,"tree").Add("foo1", StreamFor("foo1"));
 
                 tx.Commit();
             }
@@ -46,7 +46,7 @@
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
                 Env.CreateTree(tx, "tree");
-                tx.Environment.State.GetTree(tx,"tree").Add(tx, "foo1", StreamFor("foo1"));
+                tx.Environment.State.GetTree(tx,"tree").Add("foo1", StreamFor("foo1"));
 
                 tx.Commit();
             }
@@ -73,7 +73,7 @@
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
                 Env.CreateTree(tx, "tree");
-                tx.Environment.State.GetTree(tx,"tree").Add(tx, "foo1", StreamFor("foo1"));
+                tx.Environment.State.GetTree(tx,"tree").Add("foo1", StreamFor("foo1"));
 
                 tx.Commit();
             }
@@ -102,7 +102,7 @@
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
                 Env.CreateTree(tx, "tree");
-                tx.Environment.State.GetTree(tx,"tree").Add(tx, "foo1", StreamFor("foo1"));
+                tx.Environment.State.GetTree(tx,"tree").Add("foo1", StreamFor("foo1"));
 
                 tx.Commit();
             }
@@ -128,7 +128,7 @@
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
                 Env.CreateTree(tx, "tree");
-                tx.Environment.State.GetTree(tx,"tree").Add(tx, "foo1", StreamFor("foo1"));
+                tx.Environment.State.GetTree(tx,"tree").Add("foo1", StreamFor("foo1"));
 
                 tx.Commit();
             }
@@ -161,7 +161,7 @@
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
                 Env.CreateTree(tx, "tree");
-                tx.Environment.State.GetTree(tx,"tree").Add(tx, "foo1", StreamFor("foo1"));
+                tx.Environment.State.GetTree(tx,"tree").Add("foo1", StreamFor("foo1"));
 
                 tx.Commit();
             }
@@ -188,14 +188,14 @@
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
                 Env.CreateTree(tx, "tree");
-                tx.Environment.State.GetTree(tx,"tree").Add(tx, "foo1", StreamFor("foo1"));
+                tx.Environment.State.GetTree(tx,"tree").Add("foo1", StreamFor("foo1"));
 
                 tx.Commit();
             }
 
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                tx.Environment.State.GetTree(tx,"tree").Add(tx, "foo1", StreamFor("updated foo1"));
+                tx.Environment.State.GetTree(tx,"tree").Add("foo1", StreamFor("updated foo1"));
 
                 tx.Commit();
             }
@@ -224,7 +224,7 @@
 
             using (var tx = Env.NewTransaction(TransactionFlags.Read))
             {
-                var stream = tx.State.Root.Read(tx, "key/1");
+                var stream = tx.State.Root.Read("key/1");
                 Assert.Equal("123", stream.Reader.ToStringValue());
             }
         }
@@ -247,7 +247,7 @@
                 for (int i = 0; i < numberOfItems; i++)
                 {
                     {
-                        var result = tx.State.Root.Read(tx, "key/" + i).Reader.ToStringValue();
+                        var result = tx.State.Root.Read("key/" + i).Reader.ToStringValue();
                         Assert.Equal(i.ToString(CultureInfo.InvariantCulture), result);
                     }
                 }
@@ -273,10 +273,10 @@
             {
                 for (int i = 0; i < numberOfItems; i++)
                 {
-                    var result = tx.State.Root.Read(tx, "key/" + i).Reader.ToStringValue();
+                    var result = tx.State.Root.Read("key/" + i).Reader.ToStringValue();
                     Assert.Equal(i.ToString(CultureInfo.InvariantCulture), result);
 
-                    result = tx.State.Root.Read(tx, "yek/" + i).Reader.ToStringValue();
+                    result = tx.State.Root.Read("yek/" + i).Reader.ToStringValue();
                     Assert.Equal(i.ToString(CultureInfo.InvariantCulture), result);
 
                 }
@@ -311,9 +311,9 @@
             {
                 for (int i = 0; i < numberOfItems; i++)
                 {
-                    var result = tx.Environment.State.GetTree(tx,"tree1").Read(tx, "key/" + i).Reader.ToStringValue();
+                    var result = tx.Environment.State.GetTree(tx,"tree1").Read("key/" + i).Reader.ToStringValue();
                     Assert.Equal(i.ToString(CultureInfo.InvariantCulture), result);
-                    result = tx.Environment.State.GetTree(tx,"tree2").Read(tx, "yek/" + i).Reader.ToStringValue();
+                    result = tx.Environment.State.GetTree(tx,"tree2").Read("yek/" + i).Reader.ToStringValue();
                     Assert.Equal(i.ToString(CultureInfo.InvariantCulture), result);
                 }
             }
@@ -339,9 +339,9 @@
 
             using (var tx = Env.NewTransaction(TransactionFlags.Read))
             {
-                var result = tx.Environment.State.GetTree(tx,"tree1").Read(tx, "key/1").Reader.ToStringValue();
+                var result = tx.Environment.State.GetTree(tx,"tree1").Read("key/1").Reader.ToStringValue();
                 Assert.Equal("tree1", result);
-                result = tx.Environment.State.GetTree(tx,"tree2").Read(tx, "key/1").Reader.ToStringValue();
+                result = tx.Environment.State.GetTree(tx,"tree2").Read("key/1").Reader.ToStringValue();
                 Assert.Equal("tree2", result);
             }
         }
@@ -378,9 +378,9 @@
 
                 using (var tx = Env.NewTransaction(TransactionFlags.Read))
                 {
-                    var result = tx.Environment.State.GetTree(tx,"tree1").Read(tx, "key/1").Reader.ToStringValue();
+                    var result = tx.Environment.State.GetTree(tx,"tree1").Read("key/1").Reader.ToStringValue();
                     Assert.Equal("tree1", result);
-                    result = tx.Environment.State.GetTree(tx,"tree3").Read(tx, "key/1").Reader.ToStringValue();
+                    result = tx.Environment.State.GetTree(tx,"tree3").Read("key/1").Reader.ToStringValue();
                     Assert.Equal("tree3", result);
                 }
             }
@@ -429,10 +429,10 @@
 
             using (var tx = Env.NewTransaction(TransactionFlags.Read))
             {
-                var result = tx.Environment.State.GetTree(tx,"tree1").Read(tx, "key/1").Reader.ToStringValue();
+                var result = tx.Environment.State.GetTree(tx,"tree1").Read("key/1").Reader.ToStringValue();
                 Assert.Equal("tree1", result);
 
-                result = tx.Environment.State.GetTree(tx,"tree3").Read(tx, "key/1").Reader.ToStringValue();
+                result = tx.Environment.State.GetTree(tx,"tree3").Read("key/1").Reader.ToStringValue();
                 Assert.Equal("tree3", result);
             }
         }

--- a/Voron.Tests/Storage/BigValue.cs
+++ b/Voron.Tests/Storage/BigValue.cs
@@ -27,7 +27,7 @@ namespace Voron.Tests.Storage
 			random.NextBytes(buffer);
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, new Slice(BitConverter.GetBytes(1203)), new MemoryStream(buffer));
+				tx.State.Root.Add(new Slice(BitConverter.GetBytes(1203)), new MemoryStream(buffer));
 				tx.Commit();
 			}
 
@@ -40,13 +40,13 @@ namespace Voron.Tests.Storage
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Delete(tx, new Slice(BitConverter.GetBytes(1203)));
+				tx.State.Root.Delete(new Slice(BitConverter.GetBytes(1203)));
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var readResult = tx.State.Root.Read(tx, new Slice(BitConverter.GetBytes(1203)));
+				var readResult = tx.State.Root.Read(new Slice(BitConverter.GetBytes(1203)));
 				Assert.Null(readResult);
 			}
 
@@ -55,7 +55,7 @@ namespace Voron.Tests.Storage
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var readResult = tx.State.Root.Read(tx, new Slice(BitConverter.GetBytes(1203)));
+				var readResult = tx.State.Root.Read(new Slice(BitConverter.GetBytes(1203)));
 				Assert.Null(readResult);
 			}
 
@@ -63,13 +63,13 @@ namespace Voron.Tests.Storage
 			{
 				buffer = new byte[1024 * 1024 * 3 + 1238];
 				random.NextBytes(buffer);
-				tx.State.Root.Add(tx, new Slice(BitConverter.GetBytes(1203)), new MemoryStream(buffer));
+				tx.State.Root.Add(new Slice(BitConverter.GetBytes(1203)), new MemoryStream(buffer));
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var readResult = tx.State.Root.Read(tx, new Slice(BitConverter.GetBytes(1203)));
+				var readResult = tx.State.Root.Read(new Slice(BitConverter.GetBytes(1203)));
 				Assert.NotNull(readResult);
 
 				var memoryStream = new MemoryStream();
@@ -83,7 +83,7 @@ namespace Voron.Tests.Storage
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var readResult = tx.State.Root.Read(tx, new Slice(BitConverter.GetBytes(1203)));
+				var readResult = tx.State.Root.Read(new Slice(BitConverter.GetBytes(1203)));
 				Assert.NotNull(readResult);
 
 				var memoryStream = new MemoryStream();
@@ -96,7 +96,7 @@ namespace Voron.Tests.Storage
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var readResult = tx.State.Root.Read(tx, new Slice(BitConverter.GetBytes(1203)));
+				var readResult = tx.State.Root.Read(new Slice(BitConverter.GetBytes(1203)));
 				Assert.NotNull(readResult);
 
 				var memoryStream = new MemoryStream();
@@ -112,7 +112,7 @@ namespace Voron.Tests.Storage
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var readResult = tx.State.Root.Read(tx, new Slice(BitConverter.GetBytes(1203)));
+				var readResult = tx.State.Root.Read(new Slice(BitConverter.GetBytes(1203)));
 				Assert.NotNull(readResult);
 
 				var memoryStream = new MemoryStream();
@@ -137,13 +137,13 @@ namespace Voron.Tests.Storage
 			random.NextBytes(buffer);
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, new Slice(BitConverter.GetBytes(1203)), new MemoryStream(buffer));
+				tx.State.Root.Add(new Slice(BitConverter.GetBytes(1203)), new MemoryStream(buffer));
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var readResult = tx.State.Root.Read(tx, new Slice(BitConverter.GetBytes(1203)));
+				var readResult = tx.State.Root.Read(new Slice(BitConverter.GetBytes(1203)));
 				Assert.NotNull(readResult);
 
 				var memoryStream = new MemoryStream();
@@ -165,7 +165,7 @@ namespace Voron.Tests.Storage
 					var buffer = new byte[912];
 					random.NextBytes(buffer);
 					buffers.Add(buffer);
-					tx.State.Root.Add(tx, new Slice(BitConverter.GetBytes(i)), new MemoryStream(buffer));
+					tx.State.Root.Add(new Slice(BitConverter.GetBytes(i)), new MemoryStream(buffer));
 				}
 				tx.Commit();
 			}
@@ -174,7 +174,7 @@ namespace Voron.Tests.Storage
 			{
 				for (int i = 0; i < 1500; i++)
 				{
-					var readResult = tx.State.Root.Read(tx, new Slice(BitConverter.GetBytes(i)));
+					var readResult = tx.State.Root.Read(new Slice(BitConverter.GetBytes(i)));
 					Assert.NotNull(readResult);
 
 					var memoryStream = new MemoryStream();

--- a/Voron.Tests/Storage/Concurrency.cs
+++ b/Voron.Tests/Storage/Concurrency.cs
@@ -16,7 +16,7 @@ namespace Voron.Tests.Storage
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				Assert.Equal(0, tx.State.Root.ReadVersion(tx, "key/1"));
+				Assert.Equal(0, tx.State.Root.ReadVersion("key/1"));
 			}
 		}
 
@@ -25,17 +25,17 @@ namespace Voron.Tests.Storage
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "key/1", StreamFor("123"));
-				Assert.Equal(1, tx.State.Root.ReadVersion(tx, "key/1"));
-				tx.State.Root.Add(tx, "key/1", StreamFor("123"));
-				Assert.Equal(2, tx.State.Root.ReadVersion(tx, "key/1"));
+				tx.State.Root.Add("key/1", StreamFor("123"));
+				Assert.Equal(1, tx.State.Root.ReadVersion("key/1"));
+				tx.State.Root.Add("key/1", StreamFor("123"));
+				Assert.Equal(2, tx.State.Root.ReadVersion("key/1"));
 
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				Assert.Equal(2, tx.State.Root.ReadVersion(tx, "key/1"));
+				Assert.Equal(2, tx.State.Root.ReadVersion("key/1"));
 			}
 		}
 
@@ -46,13 +46,13 @@ namespace Voron.Tests.Storage
 			{
 				for (uint i = 1; i <= ushort.MaxValue + 1; i++)
 				{
-					tx.State.Root.Add(tx, "key/1", StreamFor("123"));
+					tx.State.Root.Add("key/1", StreamFor("123"));
 
 					var expected = i;
 					if (expected > ushort.MaxValue)
 						expected = 1;
 
-					Assert.Equal(expected, tx.State.Root.ReadVersion(tx, "key/1"));
+					Assert.Equal(expected, tx.State.Root.ReadVersion("key/1"));
 				}
 
 				tx.Commit();
@@ -64,15 +64,15 @@ namespace Voron.Tests.Storage
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "key/1", StreamFor("123"));
-				Assert.Equal(1, tx.State.Root.ReadVersion(tx, "key/1"));
-				tx.State.Root.Add(tx, "key/1", StreamFor("123"));
-				Assert.Equal(2, tx.State.Root.ReadVersion(tx, "key/1"));
+				tx.State.Root.Add("key/1", StreamFor("123"));
+				Assert.Equal(1, tx.State.Root.ReadVersion("key/1"));
+				tx.State.Root.Add("key/1", StreamFor("123"));
+				Assert.Equal(2, tx.State.Root.ReadVersion("key/1"));
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				Assert.Equal(0, tx.State.Root.ReadVersion(tx, "key/1"));
+				Assert.Equal(0, tx.State.Root.ReadVersion("key/1"));
 			}
 		}
 
@@ -81,11 +81,11 @@ namespace Voron.Tests.Storage
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "key/1", StreamFor("123"));
-				Assert.Equal(1, tx.State.Root.ReadVersion(tx, "key/1"));
+				tx.State.Root.Add("key/1", StreamFor("123"));
+				Assert.Equal(1, tx.State.Root.ReadVersion("key/1"));
 
-				tx.State.Root.Delete(tx, "key/1");
-				Assert.Equal(0, tx.State.Root.ReadVersion(tx, "key/1"));
+				tx.State.Root.Delete("key/1");
+				Assert.Equal(0, tx.State.Root.ReadVersion("key/1"));
 			}
 		}
 
@@ -94,15 +94,15 @@ namespace Voron.Tests.Storage
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "key/1", StreamFor("123"), 0);
-				Assert.Equal(1, tx.State.Root.ReadVersion(tx, "key/1"));
+				tx.State.Root.Add("key/1", StreamFor("123"), 0);
+				Assert.Equal(1, tx.State.Root.ReadVersion("key/1"));
 
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.Add(tx, "key/1", StreamFor("321"), 0));
+				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.Add("key/1", StreamFor("321"), 0));
 				Assert.Equal("Cannot add 'key/1' to 'Root' tree. Version mismatch. Expected: 0. Actual: 1.", e.Message);
 			}
 		}
@@ -112,21 +112,21 @@ namespace Voron.Tests.Storage
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "key/1", StreamFor("123"));
-				Assert.Equal(1, tx.State.Root.ReadVersion(tx, "key/1"));
+				tx.State.Root.Add("key/1", StreamFor("123"));
+				Assert.Equal(1, tx.State.Root.ReadVersion("key/1"));
 
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.Add(tx, "key/1", StreamFor("321"), 2));
+				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.Add("key/1", StreamFor("321"), 2));
 				Assert.Equal("Cannot add 'key/1' to 'Root' tree. Version mismatch. Expected: 2. Actual: 1.", e.Message);
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.Delete(tx, "key/1", 2));
+				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.Delete("key/1", 2));
 				Assert.Equal("Cannot delete 'key/1' to 'Root' tree. Version mismatch. Expected: 2. Actual: 1.", e.Message);
 			}
 		}
@@ -136,21 +136,21 @@ namespace Voron.Tests.Storage
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.MultiAdd(tx, "key/1", "123");
-				Assert.Equal(1, tx.State.Root.ReadVersion(tx, "key/1"));
+				tx.State.Root.MultiAdd("key/1", "123");
+				Assert.Equal(1, tx.State.Root.ReadVersion("key/1"));
 
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.MultiAdd(tx, "key/1", "321", version: 2));
+				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.MultiAdd("key/1", "321", version: 2));
 				Assert.Equal("Cannot add value '321' to key 'key/1' to 'Root' tree. Version mismatch. Expected: 2. Actual: 0.", e.Message);
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.MultiDelete(tx, "key/1", "123", 2));
+				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.MultiDelete("key/1", "123", 2));
 				Assert.Equal("Cannot delete value '123' to key 'key/1' to 'Root' tree. Version mismatch. Expected: 2. Actual: 1.", e.Message);
 			}
 		}
@@ -165,7 +165,7 @@ namespace Voron.Tests.Storage
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				Assert.Equal(1, tx.State.Root.ReadVersion(tx, "key/1"));
+				Assert.Equal(1, tx.State.Root.ReadVersion("key/1"));
 			}
 
 			var batch2 = new WriteBatch();
@@ -175,7 +175,7 @@ namespace Voron.Tests.Storage
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				Assert.Equal(2, tx.State.Root.ReadVersion(tx, "key/1"));
+				Assert.Equal(2, tx.State.Root.ReadVersion("key/1"));
 			}
 		}
 
@@ -189,7 +189,7 @@ namespace Voron.Tests.Storage
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				Assert.Equal(1, tx.State.Root.ReadVersion(tx, "key/1"));
+				Assert.Equal(1, tx.State.Root.ReadVersion("key/1"));
 			}
 
 			var batch2 = new WriteBatch();
@@ -199,7 +199,7 @@ namespace Voron.Tests.Storage
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				Assert.Equal(0, tx.State.Root.ReadVersion(tx, "key/1"));
+				Assert.Equal(0, tx.State.Root.ReadVersion("key/1"));
 			}
 		}
 
@@ -213,7 +213,7 @@ namespace Voron.Tests.Storage
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				Assert.Equal(1, tx.State.Root.ReadVersion(tx, "key/1"));
+				Assert.Equal(1, tx.State.Root.ReadVersion("key/1"));
 			}
 
 			var batch2 = new WriteBatch();

--- a/Voron.Tests/Storage/Concurrency.cs
+++ b/Voron.Tests/Storage/Concurrency.cs
@@ -103,7 +103,7 @@ namespace Voron.Tests.Storage
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
 				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.Add(tx, "key/1", StreamFor("321"), 0));
-				Assert.Equal("Cannot add 'key/1'. Version mismatch. Expected: 0. Actual: 1.", e.Message);
+				Assert.Equal("Cannot add 'key/1' to 'Root' tree. Version mismatch. Expected: 0. Actual: 1.", e.Message);
 			}
 		}
 
@@ -121,13 +121,13 @@ namespace Voron.Tests.Storage
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
 				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.Add(tx, "key/1", StreamFor("321"), 2));
-				Assert.Equal("Cannot add 'key/1'. Version mismatch. Expected: 2. Actual: 1.", e.Message);
+				Assert.Equal("Cannot add 'key/1' to 'Root' tree. Version mismatch. Expected: 2. Actual: 1.", e.Message);
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
 				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.Delete(tx, "key/1", 2));
-				Assert.Equal("Cannot delete 'key/1'. Version mismatch. Expected: 2. Actual: 1.", e.Message);
+				Assert.Equal("Cannot delete 'key/1' to 'Root' tree. Version mismatch. Expected: 2. Actual: 1.", e.Message);
 			}
 		}
 
@@ -144,14 +144,14 @@ namespace Voron.Tests.Storage
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.MultiAdd(tx, "key/1", "321", 2));
-				Assert.Equal("Cannot add 'key/1'. Version mismatch. Expected: 2. Actual: 1.", e.Message);
+				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.MultiAdd(tx, "key/1", "321", version: 2));
+				Assert.Equal("Cannot add value '321' to key 'key/1' to 'Root' tree. Version mismatch. Expected: 2. Actual: 0.", e.Message);
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
 				var e = Assert.Throws<ConcurrencyException>(() => tx.State.Root.MultiDelete(tx, "key/1", "123", 2));
-				Assert.Equal("Cannot delete 'key/1'. Version mismatch. Expected: 2. Actual: 1.", e.Message);
+				Assert.Equal("Cannot delete value '123' to key 'key/1' to 'Root' tree. Version mismatch. Expected: 2. Actual: 1.", e.Message);
 			}
 		}
 
@@ -220,7 +220,7 @@ namespace Voron.Tests.Storage
             batch2.Add("key/1", StreamFor("123"), Constants.RootTreeName, 0);
 
 			var e = Assert.Throws<AggregateException>(() => Env.Writer.Write(batch2)).InnerException;
-			Assert.Equal("Cannot add 'key/1'. Version mismatch. Expected: 0. Actual: 1.", e.Message);
+			Assert.Equal("Cannot add 'key/1' to 'Root' tree. Version mismatch. Expected: 0. Actual: 1.", e.Message);
 		}
 
 		[Fact]
@@ -235,13 +235,13 @@ namespace Voron.Tests.Storage
             batch2.Add("key/1", StreamFor("123"), Constants.RootTreeName, 2);
 
 			var e = Assert.Throws<AggregateException>(() => Env.Writer.Write(batch2)).InnerException;
-			Assert.Equal("Cannot add 'key/1'. Version mismatch. Expected: 2. Actual: 1.", e.Message);
+			Assert.Equal("Cannot add 'key/1' to 'Root' tree. Version mismatch. Expected: 2. Actual: 1.", e.Message);
 
 			var batch3 = new WriteBatch();
             batch3.Delete("key/1", Constants.RootTreeName, 2);
 
 			e = Assert.Throws<AggregateException>(() => Env.Writer.Write(batch3)).InnerException;
-			Assert.Equal("Cannot delete 'key/1'. Version mismatch. Expected: 2. Actual: 1.", e.Message);
+			Assert.Equal("Cannot delete 'key/1' to 'Root' tree. Version mismatch. Expected: 2. Actual: 1.", e.Message);
 		}
 
         [Fact]

--- a/Voron.Tests/Storage/Files.cs
+++ b/Voron.Tests/Storage/Files.cs
@@ -1,0 +1,78 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="Files.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System.IO;
+
+using Xunit;
+
+namespace Voron.Tests.Storage
+{
+    public class Files : StorageTest
+    {
+        private readonly string path;
+
+        private readonly string temp;
+
+        public Files()
+        {
+            path = Path.GetFullPath("Data");
+            temp = Path.GetFullPath("Temp");
+
+            DeleteDirectory(path);
+            DeleteDirectory(temp);
+        }
+
+        [Fact]
+        public void ByDefaultAllFilesShouldBeStoredInOneDirectory()
+        {
+            var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(path);
+
+            Assert.Equal(path, options.BasePath);
+            Assert.Equal(options.BasePath, options.TempPath);
+        }
+
+        [Fact]
+        public void TemporaryPathTest()
+        {
+            var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(path, temp);
+
+            Assert.Equal(path, options.BasePath);
+            Assert.Equal(temp, options.TempPath);
+        }
+
+        [Fact]
+        public void DefaultScratchLocation()
+        {
+            var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(path);
+            using (var env = new StorageEnvironment(options))
+            {
+                var scratchFile = Path.Combine(path, "scratch.buffers");
+                Assert.True(File.Exists(scratchFile));
+            }
+        }
+
+        [Fact]
+        public void ScratchLocationWithTemporaryPathSpecified()
+        {
+            var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(path, temp);
+            using (var env = new StorageEnvironment(options))
+            {
+                var scratchFile = Path.Combine(path, "scratch.buffers");
+                var scratchFileTemp = Path.Combine(temp, "scratch.buffers");
+
+                Assert.False(File.Exists(scratchFile));
+                Assert.True(File.Exists(scratchFileTemp));
+            }
+        }
+
+        public override void Dispose()
+        {
+            DeleteDirectory(path);
+            DeleteDirectory(temp);
+
+            base.Dispose();
+        }
+    }
+}

--- a/Voron.Tests/Storage/FreeScratchPages.cs
+++ b/Voron.Tests/Storage/FreeScratchPages.cs
@@ -27,7 +27,7 @@ namespace Voron.Tests.Storage
 			{
 				for (int i = 0; i < 10; i++)
 				{
-					tx.State.Root.Add(tx, "items/" + i, new MemoryStream(buffer));
+					tx.State.Root.Add("items/" + i, new MemoryStream(buffer));
 				}
 
 				scratchPagesOfUncommittedTransaction = tx.GetTransactionPages();
@@ -42,7 +42,7 @@ namespace Voron.Tests.Storage
 				// let's do exactly the same, it should reuse the same scratch pages
 				for (int i = 0; i < 10; i++)
 				{
-					tx.State.Root.Add(tx, "items/" + i, new MemoryStream(buffer));
+					tx.State.Root.Add("items/" + i, new MemoryStream(buffer));
 				}
 
 				scratchPagesOfCommittedTransaction = tx.GetTransactionPages();

--- a/Voron.Tests/Storage/Increments.cs
+++ b/Voron.Tests/Storage/Increments.cs
@@ -1,0 +1,80 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="Increments.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using Voron.Impl;
+
+using Xunit;
+
+namespace Voron.Tests.Storage
+{
+	public class Increments : StorageTest
+	{
+		[Fact]
+		public void SimpleIncrementShouldWork()
+		{
+			CreateTrees(Env, 1, "tree");
+
+			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				Assert.Equal(10, tx.ReadTree("tree0").Increment(tx, "key/1", 10));
+
+				tx.Commit();
+			}
+
+			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				Assert.Equal(15, tx.ReadTree("tree0").Increment(tx, "key/1", 5));
+
+				tx.Commit();
+			}
+
+			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				Assert.Equal(12, tx.ReadTree("tree0").Increment(tx, "key/1", -3));
+
+				tx.Commit();
+			}
+
+			using (var tx = Env.NewTransaction(TransactionFlags.Read))
+			{
+				var read = tx.ReadTree("tree0").Read(tx, "key/1");
+
+				Assert.NotNull(read);
+				Assert.Equal(3, read.Version);
+				Assert.Equal(12, read.Reader.ReadLittleEndianInt64());
+			}
+		}
+
+		[Fact]
+		public void SimpleIncrementShouldWorkUsingWriteBatch()
+		{
+			CreateTrees(Env, 1, "tree");
+
+			var writeBatch = new WriteBatch();
+			writeBatch.Increment("key/1", 10, "tree0");
+
+			Env.Writer.Write(writeBatch);
+
+			writeBatch = new WriteBatch();
+			writeBatch.Increment("key/1", 5, "tree0");
+
+			Env.Writer.Write(writeBatch);
+
+			writeBatch = new WriteBatch();
+			writeBatch.Increment("key/1", -3, "tree0");
+
+			Env.Writer.Write(writeBatch);
+
+			using (var tx = Env.NewTransaction(TransactionFlags.Read))
+			{
+				var read = tx.ReadTree("tree0").Read(tx, "key/1");
+
+				Assert.NotNull(read);
+				Assert.Equal(3, read.Version);
+				Assert.Equal(12, read.Reader.ReadLittleEndianInt64());
+			}
+		}
+	}
+}

--- a/Voron.Tests/Storage/Increments.cs
+++ b/Voron.Tests/Storage/Increments.cs
@@ -18,28 +18,28 @@ namespace Voron.Tests.Storage
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				Assert.Equal(10, tx.ReadTree("tree0").Increment(tx, "key/1", 10));
+				Assert.Equal(10, tx.ReadTree("tree0").Increment("key/1", 10));
 
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				Assert.Equal(15, tx.ReadTree("tree0").Increment(tx, "key/1", 5));
+				Assert.Equal(15, tx.ReadTree("tree0").Increment("key/1", 5));
 
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				Assert.Equal(12, tx.ReadTree("tree0").Increment(tx, "key/1", -3));
+				Assert.Equal(12, tx.ReadTree("tree0").Increment("key/1", -3));
 
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var read = tx.ReadTree("tree0").Read(tx, "key/1");
+				var read = tx.ReadTree("tree0").Read("key/1");
 
 				Assert.NotNull(read);
 				Assert.Equal(3, read.Version);
@@ -69,7 +69,7 @@ namespace Voron.Tests.Storage
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var read = tx.ReadTree("tree0").Read(tx, "key/1");
+				var read = tx.ReadTree("tree0").Read("key/1");
 
 				Assert.NotNull(read);
 				Assert.Equal(3, read.Version);

--- a/Voron.Tests/Storage/InitialSize.cs
+++ b/Voron.Tests/Storage/InitialSize.cs
@@ -1,0 +1,91 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="InitialSize.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.IO;
+
+using Voron.Impl;
+
+using Xunit;
+
+namespace Voron.Tests.Storage
+{
+	public class InitialSize : StorageTest
+	{
+		private readonly string path;
+
+		public InitialSize()
+		{
+			path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+			if (Directory.Exists(path))
+				Directory.Delete(path, true);
+		}
+
+		[Fact]
+		public void WhenInitialFileSizeIsNotSetTheFileSizeForDataFileAndScratchFileShouldBeSetToSystemAllocationGranularity()
+		{
+			NativeMethods.SYSTEM_INFO systemInfo;
+			NativeMethods.GetSystemInfo(out systemInfo);
+
+			var options = StorageEnvironmentOptions.ForPath(path);
+			options.InitialFileSize = null;
+
+			using (new StorageEnvironment(options))
+			{
+				var dataFile = Path.Combine(path, Constants.DatabaseFilename);
+				var scratchFile = Path.Combine(path, "scratch.buffers");
+
+				Assert.Equal(systemInfo.allocationGranularity, new FileInfo(dataFile).Length);
+				Assert.Equal(systemInfo.allocationGranularity, new FileInfo(scratchFile).Length);
+			}
+		}
+
+		[Fact]
+		public void WhenInitialFileSizeIsSetTheFileSizeForDataFileAndScratchFileShouldBeSetAccordingly()
+		{
+			NativeMethods.SYSTEM_INFO systemInfo;
+			NativeMethods.GetSystemInfo(out systemInfo);
+
+			var options = StorageEnvironmentOptions.ForPath(path);
+			options.InitialFileSize = systemInfo.allocationGranularity * 2;
+
+			using (new StorageEnvironment(options))
+			{
+				var dataFile = Path.Combine(path, Constants.DatabaseFilename);
+				var scratchFile = Path.Combine(path, "scratch.buffers");
+
+				Assert.Equal(systemInfo.allocationGranularity * 2, new FileInfo(dataFile).Length);
+				Assert.Equal(systemInfo.allocationGranularity * 2, new FileInfo(scratchFile).Length);
+			}
+		}
+
+		[Fact]
+		public void WhenInitialFileSizeIsSetTheFileSizeForDataFileAndScratchFileShouldBeSetAccordinglyAndItWillBeRoundedToTheNearestGranularity()
+		{
+			NativeMethods.SYSTEM_INFO systemInfo;
+			NativeMethods.GetSystemInfo(out systemInfo);
+
+			var options = StorageEnvironmentOptions.ForPath(path);
+			options.InitialFileSize = systemInfo.allocationGranularity * 2 + 1;
+
+			using (new StorageEnvironment(options))
+			{
+				var dataFile = Path.Combine(path, Constants.DatabaseFilename);
+				var scratchFile = Path.Combine(path, "scratch.buffers");
+
+				Assert.Equal(systemInfo.allocationGranularity * 3, new FileInfo(dataFile).Length);
+				Assert.Equal(systemInfo.allocationGranularity * 3, new FileInfo(scratchFile).Length);
+			}
+		}
+
+		public override void Dispose()
+		{
+			if (!string.IsNullOrEmpty(path) && Directory.Exists(path))
+				Directory.Delete(path, true);
+
+			base.Dispose();
+		}
+	}
+}

--- a/Voron.Tests/Storage/MemoryMapWithoutBackingPagerTest.cs
+++ b/Voron.Tests/Storage/MemoryMapWithoutBackingPagerTest.cs
@@ -108,7 +108,7 @@ namespace Voron.Tests.Storage
 		    {
 		        var tree = tx.ReadTree(TestTreeName);
 		        foreach (var dataPair in testData)
-		            tree.Add(tx, dataPair.Key, StreamFor(dataPair.Value));
+		            tree.Add(dataPair.Key, StreamFor(dataPair.Value));
 
 		        tx.Commit();
 		    }

--- a/Voron.Tests/Storage/MultiTransactions.cs
+++ b/Voron.Tests/Storage/MultiTransactions.cs
@@ -23,7 +23,7 @@ namespace Voron.Tests.Storage
                         {
                             ms.Position = 0;
                             
-                            tx.State.Root.Add(tx, (x * i).ToString("0000000000000000"), ms);
+                            tx.State.Root.Add((x * i).ToString("0000000000000000"), ms);
                         }
 
                         tx.Commit();

--- a/Voron.Tests/Storage/Pagers.cs
+++ b/Voron.Tests/Storage/Pagers.cs
@@ -25,7 +25,7 @@ namespace Voron.Tests.Storage
 		[Fact]	
 	    public void MemoryMapWithoutBackingReleasePagerState()
 	    {
-		    PagerReleasesPagerState(() => new Win32PageFileBackedMemoryMappedPager());
+		    PagerReleasesPagerState(() => new Win32PageFileBackedMemoryMappedPager("test"));
 	    }
 
         [Fact]

--- a/Voron.Tests/Storage/Quotas.cs
+++ b/Voron.Tests/Storage/Quotas.cs
@@ -27,7 +27,7 @@ namespace Voron.Tests.Storage
 				{
 					for (int i = 0; i < 1024; i++)
 					{
-						tx.State.Root.Add(tx, "items/" + i, new MemoryStream(new byte[1024]));
+						tx.State.Root.Add("items/" + i, new MemoryStream(new byte[1024]));
 					}
 
 					tx.Commit();

--- a/Voron.Tests/Storage/Restarts.cs
+++ b/Voron.Tests/Storage/Restarts.cs
@@ -20,12 +20,12 @@ namespace Voron.Tests.Storage
                 {
                     using (var tx = env.NewTransaction(TransactionFlags.ReadWrite))
                     {
-                        tx.State.Root.Add(tx, "test/1", new MemoryStream());
+                        tx.State.Root.Add("test/1", new MemoryStream());
                         tx.Commit();
                     }
                     using (var tx = env.NewTransaction(TransactionFlags.ReadWrite))
                     {
-                        tx.State.Root.Add(tx, "test/2", new MemoryStream());
+                        tx.State.Root.Add("test/2", new MemoryStream());
                         tx.Commit();
                     }
                 }
@@ -34,11 +34,11 @@ namespace Voron.Tests.Storage
                 {
                     using (var tx = env.NewTransaction(TransactionFlags.Read))
                     {
-	                    if (tx.State.Root.Read(tx, "test/1") == null)
+	                    if (tx.State.Root.Read("test/1") == null)
 		                    Debugger.Launch();
 
-                        Assert.NotNull(tx.State.Root.Read(tx, "test/1"));
-                        Assert.NotNull(tx.State.Root.Read(tx, "test/2"));
+                        Assert.NotNull(tx.State.Root.Read("test/1"));
+                        Assert.NotNull(tx.State.Root.Read("test/2"));
                         tx.Commit();
                     }
                 }
@@ -61,10 +61,10 @@ namespace Voron.Tests.Storage
                     using (var tx = env.NewTransaction(TransactionFlags.ReadWrite))
                     {
                         var tree = tx.Environment.State.GetTree(tx,"test");
-                        tree.Add(tx, "test", Stream.Null);
+                        tree.Add("test", Stream.Null);
                         tx.Commit();
 
-                        Assert.NotNull(tree.Read(tx, "test"));
+                        Assert.NotNull(tree.Read("test"));
                     }
                 }
 
@@ -79,7 +79,7 @@ namespace Voron.Tests.Storage
                     using (var tx = env.NewTransaction(TransactionFlags.Read))
                     {
                         var tree = tx.Environment.State.GetTree(tx,"test");
-                        Assert.NotNull(tree.Read(tx, "test"));
+                        Assert.NotNull(tree.Read("test"));
                         tx.Commit();
                     }
                 }

--- a/Voron.Tests/Storage/Snapshots.cs
+++ b/Voron.Tests/Storage/Snapshots.cs
@@ -28,7 +28,7 @@ namespace Voron.Tests.Storage
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "key/1", new MemoryStream(Encoding.UTF8.GetBytes("123")));
+				tx.State.Root.Add("key/1", new MemoryStream(Encoding.UTF8.GetBytes("123")));
 
 				tx.Commit();
 			}
@@ -36,7 +36,7 @@ namespace Voron.Tests.Storage
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-                var reader = tx.State.Root.Read(tx, "key/1").Reader;
+                var reader = tx.State.Root.Read("key/1").Reader;
 			    Assert.Equal("123", reader.ToStringValue());
 			    tx.Commit();
 			}

--- a/Voron.Tests/Storage/SplittingVeryBig.cs
+++ b/Voron.Tests/Storage/SplittingVeryBig.cs
@@ -1,4 +1,5 @@
-﻿using Voron.Impl;
+﻿using System.Linq;
+using Voron.Impl;
 using Voron.Impl.Paging;
 
 namespace Voron.Tests.Storage
@@ -41,7 +42,8 @@ namespace Voron.Tests.Storage
 
 			    var reader = read.Reader;
 			    Assert.Equal(buffer.Length, read.Reader.Length);
-			    Assert.Equal(buffer, reader.ReadBytes(read.Reader.Length));
+				int used;
+				Assert.Equal(buffer, reader.ReadBytes(read.Reader.Length, out used).Take(used).ToArray());
 			}
 		}
 
@@ -90,7 +92,8 @@ namespace Voron.Tests.Storage
 
 					{
 						Assert.Equal(buffer.Length, read.Reader.Length);
-						Assert.Equal(buffer, read.Reader.ReadBytes(read.Reader.Length));
+						int used;
+						Assert.Equal(buffer, read.Reader.ReadBytes(read.Reader.Length, out used).Take(used).ToArray());
 					}
 				}
 			}

--- a/Voron.Tests/Storage/SplittingVeryBig.cs
+++ b/Voron.Tests/Storage/SplittingVeryBig.cs
@@ -31,13 +31,13 @@ namespace Voron.Tests.Storage
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.Environment.State.GetTree(tx,"tree").Add(tx, "key1", new MemoryStream(buffer));
+				tx.Environment.State.GetTree(tx,"tree").Add("key1", new MemoryStream(buffer));
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-			    var read = tx.Environment.State.GetTree(tx,"tree").Read(tx, "key1");
+			    var read = tx.Environment.State.GetTree(tx,"tree").Read("key1");
 			    Assert.NotNull(read);
 
 			    var reader = read.Reader;
@@ -69,7 +69,7 @@ namespace Voron.Tests.Storage
 
 				using (var tx = env.NewTransaction(TransactionFlags.ReadWrite))
 				{
-					tx.Environment.State.GetTree(tx,"tree").Add(tx, "key1", new MemoryStream(buffer));
+					tx.Environment.State.GetTree(tx,"tree").Add("key1", new MemoryStream(buffer));
 					tx.Commit();
 				}
 			}
@@ -87,7 +87,7 @@ namespace Voron.Tests.Storage
 
 				using (var tx = env.NewTransaction(TransactionFlags.Read))
 				{
-					var read = tx.Environment.State.GetTree(tx,"tree").Read(tx, "key1");
+					var read = tx.Environment.State.GetTree(tx,"tree").Read("key1");
 					Assert.NotNull(read);
 
 					{

--- a/Voron.Tests/Storage/VeryBig.cs
+++ b/Voron.Tests/Storage/VeryBig.cs
@@ -25,7 +25,7 @@ namespace Voron.Tests.Storage
 					var tree = tx.Environment.State.GetTree(tx,"test");
 					for (int j = 0; j < 12; j++)
 					{
-						tree.Add(tx, string.Format("{0:000}-{1:000}", j, i), new MemoryStream(buffer));
+						tree.Add(string.Format("{0:000}-{1:000}", j, i), new MemoryStream(buffer));
 					}
 					tx.Commit();
 				}
@@ -44,7 +44,7 @@ namespace Voron.Tests.Storage
 				{
 					for (int j = 0; j < 12; j++)
 					{
-						tx.State.Root.Add(tx, string.Format("{0:000}-{1:000}", j, i), new MemoryStream(buffer));
+						tx.State.Root.Add(string.Format("{0:000}-{1:000}", j, i), new MemoryStream(buffer));
 					}
 					tx.Commit();
 				}
@@ -68,7 +68,7 @@ namespace Voron.Tests.Storage
 
 					for (int j = 0; j < 12; j++)
 					{
-						tx.State.Root.Add(tx, string.Format("{0:000}-{1:000}", j, i), new MemoryStream(buffer));
+						tx.State.Root.Add(string.Format("{0:000}-{1:000}", j, i), new MemoryStream(buffer));
 					}
 					tx.Commit();
 				}

--- a/Voron.Tests/StorageTest.cs
+++ b/Voron.Tests/StorageTest.cs
@@ -151,7 +151,7 @@ namespace Voron.Tests
 		protected unsafe Tuple<Slice, Slice> ReadKey(Transaction tx, Slice key)
 		{
 			Lazy<Cursor> lazy;
-			var p = tx.State.Root.FindPageFor(tx, key, out lazy);
+			var p = tx.State.Root.FindPageFor(key, out lazy);
 			var node = p.Search(key, Env.SliceComparer);
 
 			if (node == null)

--- a/Voron.Tests/Trees/Basic.cs
+++ b/Voron.Tests/Trees/Basic.cs
@@ -20,8 +20,8 @@ namespace Voron.Tests.Trees
             List<long> allPages = null;
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                tx.State.Root.Add(tx, "a", new MemoryStream(buffer));
-                allPages = tx.State.Root.AllPages(tx);
+                tx.State.Root.Add("a", new MemoryStream(buffer));
+                allPages = tx.State.Root.AllPages();
                 tx.Commit();
             }
 
@@ -38,7 +38,7 @@ namespace Voron.Tests.Trees
         {
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                tx.State.Root.Add(tx, "test", StreamFor("value"));
+                tx.State.Root.Add("test", StreamFor("value"));
             }
         }
 
@@ -47,9 +47,9 @@ namespace Voron.Tests.Trees
         {
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                tx.State.Root.Add(tx, "b", StreamFor("2"));
-                tx.State.Root.Add(tx, "c", StreamFor("3"));
-                tx.State.Root.Add(tx, "a", StreamFor("1"));
+                tx.State.Root.Add("b", StreamFor("2"));
+                tx.State.Root.Add("c", StreamFor("3"));
+                tx.State.Root.Add("a", StreamFor("1"));
                 var actual = ReadKey(tx, "a");
 
                 Assert.Equal("a", actual.Item1);
@@ -63,7 +63,7 @@ namespace Voron.Tests.Trees
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
                 Slice key = "test";
-                tx.State.Root.Add(tx, key, StreamFor("value"));
+                tx.State.Root.Add(key, StreamFor("value"));
 
                 tx.Commit();
 
@@ -82,7 +82,7 @@ namespace Voron.Tests.Trees
                 for (int i = 0; i < 256; i++)
                 {
                     stream.Position = 0;
-                    tx.State.Root.Add(tx, "test-" + i, stream);
+                    tx.State.Root.Add("test-" + i, stream);
 
                 }
 
@@ -107,7 +107,7 @@ namespace Voron.Tests.Trees
             {
                 for (int i = 0; i < count; i++)
                 {
-                    tx.State.Root.Add(tx, "test-" + i.ToString("000"), StreamFor("val-" + i));
+                    tx.State.Root.Add("test-" + i.ToString("000"), StreamFor("val-" + i));
 
                 }
 
@@ -140,7 +140,7 @@ namespace Voron.Tests.Trees
                         {
 
                         }
-                        tx.State.Root.Add(tx, "test-" + j.ToString("000") + "-" + i.ToString("000"), stream);
+                        tx.State.Root.Add("test-" + j.ToString("000") + "-" + i.ToString("000"), stream);
                     }
                 }
 

--- a/Voron.Tests/Trees/CanDefrag.cs
+++ b/Voron.Tests/Trees/CanDefrag.cs
@@ -16,7 +16,7 @@ namespace Voron.Tests.Trees
             {
                 for (int i = 0; i < size; i++)
                 {
-                    tx.State.Root.Add(tx, string.Format("{0,5}", i*2), StreamFor("abcdefg"));
+                    tx.State.Root.Add(string.Format("{0,5}", i*2), StreamFor("abcdefg"));
                 }
                 tx.Commit();
             }
@@ -24,7 +24,7 @@ namespace Voron.Tests.Trees
             {
                 for (int i = 0; i < size/2; i++)
                 {
-                    tx.State.Root.Delete(tx, string.Format("{0,5}", i*2));
+                    tx.State.Root.Delete(string.Format("{0,5}", i*2));
                 }
                 tx.Commit();
             }
@@ -32,7 +32,7 @@ namespace Voron.Tests.Trees
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
                 var pageCount = tx.State.Root.State.PageCount;
-                tx.State.Root.Add(tx,  "  244",new MemoryStream(new byte[512]));
+                tx.State.Root.Add( "  244",new MemoryStream(new byte[512]));
                 Assert.Equal(pageCount, tx.State.Root.State.PageCount);
                 tx.Commit();
             }

--- a/Voron.Tests/Trees/CanIterateBackward.cs
+++ b/Voron.Tests/Trees/CanIterateBackward.cs
@@ -9,7 +9,7 @@ namespace Voron.Tests.Trees
 		public void SeekLastOnEmptyResultInFalse()
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
-			using (var it = tx.State.Root.Iterate(tx))
+			using (var it = tx.State.Root.Iterate())
 			{
 				Assert.False(it.Seek(Slice.AfterAllKeys));
 
@@ -22,15 +22,15 @@ namespace Voron.Tests.Trees
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "a", new MemoryStream(0));
-				tx.State.Root.Add(tx, "c", new MemoryStream(0));
-				tx.State.Root.Add(tx, "b", new MemoryStream(0));
+				tx.State.Root.Add("a", new MemoryStream(0));
+				tx.State.Root.Add("c", new MemoryStream(0));
+				tx.State.Root.Add("b", new MemoryStream(0));
 
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
-			using (var it = tx.State.Root.Iterate(tx))
+			using (var it = tx.State.Root.Iterate())
 			{
 				Assert.True(it.Seek(Slice.AfterAllKeys));
 				Assert.Equal("c", it.CurrentKey.ToString());
@@ -44,15 +44,15 @@ namespace Voron.Tests.Trees
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "a", new MemoryStream(0));
-				tx.State.Root.Add(tx, "c", new MemoryStream(0));
-				tx.State.Root.Add(tx, "b", new MemoryStream(0));
+				tx.State.Root.Add("a", new MemoryStream(0));
+				tx.State.Root.Add("c", new MemoryStream(0));
+				tx.State.Root.Add("b", new MemoryStream(0));
 
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
-			using (var it = tx.State.Root.Iterate(tx))
+			using (var it = tx.State.Root.Iterate())
 			{
 				Assert.True(it.Seek(Slice.AfterAllKeys));
 				Assert.Equal("c", it.CurrentKey.ToString());

--- a/Voron.Tests/Trees/Deletes.cs
+++ b/Voron.Tests/Trees/Deletes.cs
@@ -19,7 +19,7 @@ namespace Voron.Tests.Trees
 
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "a", new MemoryStream(buffer));
+				tx.State.Root.Add("a", new MemoryStream(buffer));
 
 				tx.Commit();
 			}
@@ -32,7 +32,7 @@ namespace Voron.Tests.Trees
 
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Delete(tx, "a");
+				tx.State.Root.Delete("a");
 
 				tx.Commit();
 			}
@@ -46,7 +46,7 @@ namespace Voron.Tests.Trees
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				Assert.Null(tx.State.Root.Read(tx, "a"));
+				Assert.Null(tx.State.Root.Read("a"));
 
 				tx.Commit();
 			}
@@ -61,7 +61,7 @@ namespace Voron.Tests.Trees
 			 {
 				 for (int i = 0; i < 1000; i++)
 				 {
-					 tx.State.Root.Add(tx, string.Format("{0,5}",i), StreamFor("abcdefg"));
+					 tx.State.Root.Add(string.Format("{0,5}",i), StreamFor("abcdefg"));
 				 }
 				 tx.Commit();
 			 }
@@ -76,7 +76,7 @@ namespace Voron.Tests.Trees
 			 {
 				 for (int i = 0; i < 15; i++)
 				 {
-					 tx.State.Root.Delete(tx, string.Format("{0,5}", i));
+					 tx.State.Root.Delete(string.Format("{0,5}", i));
 				 }
 				 tx.Commit();
 			 }
@@ -92,7 +92,7 @@ namespace Voron.Tests.Trees
         public unsafe List<Slice> Keys(Tree t, Transaction tx)
         {
             var results = new List<Slice>();
-            using (var it = t.Iterate(tx))
+            using (var it = t.Iterate())
             {
                 if (it.Seek(Slice.BeforeAllKeys) == false)
                     return results;

--- a/Voron.Tests/Trees/FreeSpaceTest.cs
+++ b/Voron.Tests/Trees/FreeSpaceTest.cs
@@ -19,7 +19,7 @@ namespace Voron.Tests.Trees
 			{
 				for (int i = 0; i < 25; i++)
 				{
-					tx.State.Root.Add(tx, i.ToString("0000"), new MemoryStream(buffer));
+					tx.State.Root.Add(i.ToString("0000"), new MemoryStream(buffer));
 				}
 
 				tx.Commit();
@@ -30,7 +30,7 @@ namespace Voron.Tests.Trees
 			{
 				for (int i = 0; i < 25; i++)
 				{
-					tx.State.Root.Delete(tx, i.ToString("0000"));
+					tx.State.Root.Delete(i.ToString("0000"));
 				}
 
 				tx.Commit();
@@ -41,7 +41,7 @@ namespace Voron.Tests.Trees
 			{
 				for (int i = 0; i < 25; i++)
 				{
-					tx.State.Root.Add(tx, i.ToString("0000"), new MemoryStream(buffer));
+					tx.State.Root.Add(i.ToString("0000"), new MemoryStream(buffer));
 				}
 
 				tx.Commit();

--- a/Voron.Tests/Trees/FreeSpaceTest.cs
+++ b/Voron.Tests/Trees/FreeSpaceTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Voron.Impl.FreeSpace;
 using Xunit;
@@ -67,6 +68,111 @@ namespace Voron.Tests.Trees
 			{
 				Assert.Equal(FreeSpaceHandling.NumberOfPagesInSection + 1, Env.FreeSpaceHandling.TryAllocateFromFreeSpace(tx, 1));
 			}
+		}
+
+		[Fact]
+		public void CanReuseMostOfFreePages_RemainingOnesCanBeTakenToHandleFreeSpace()
+		{
+			const int maxPageNumber = 4000000;
+			const int numberOfFreedPages = 100;
+			var random = new Random(3);
+			var freedPages = new HashSet<long>();
+
+			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				tx.State.NextPageNumber = maxPageNumber + 1;
+
+				tx.Commit();
+			}
+
+			for (int i = 0; i < numberOfFreedPages; i++)
+			{
+				long pageToFree;
+				do
+				{
+					pageToFree = random.Next(0, maxPageNumber);
+				} while (freedPages.Add(pageToFree) == false);
+
+				using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+				{
+					Env.FreeSpaceHandling.FreePage(tx, pageToFree);
+
+					tx.Commit();
+				}
+			}
+
+			// we cannot expect that all freed pages will be available for a reuse
+			// some freed pages can be used internally by free space handling
+			// 80% should be definitely a safe value
+
+			var minNumberOfFreePages = numberOfFreedPages * 0.8;
+
+			for (int i = 0; i < minNumberOfFreePages; i++)
+			{
+				using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+				{
+					var page = Env.FreeSpaceHandling.TryAllocateFromFreeSpace(tx, 1);
+
+					Assert.NotNull(page);
+					Assert.True(freedPages.Remove(page.Value));
+
+					tx.Commit();
+				}
+			}
+		}
+
+		[Fact]
+		public void FreeSpaceHandlingShouldNotReturnPagesThatAreAlreadyAllocated()
+		{
+			const int maxPageNumber = 400000;
+			const int numberOfFreedPages = 60;
+			var random = new Random(2);
+			var freedPages = new HashSet<long>();
+
+			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				tx.State.NextPageNumber = maxPageNumber + 1;
+
+				tx.Commit();
+			}
+
+			for (int i = 0; i < numberOfFreedPages; i++)
+			{
+				long pageToFree;
+				do
+				{
+					pageToFree = random.Next(0, maxPageNumber);
+				} while (freedPages.Add(pageToFree) == false);
+
+				using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+				{
+					Env.FreeSpaceHandling.FreePage(tx, pageToFree);
+
+					tx.Commit();
+				}
+			}
+
+			var alreadyReused = new List<long>();
+
+			do
+			{
+				using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+				{
+					var page = Env.FreeSpaceHandling.TryAllocateFromFreeSpace(tx, 1);
+
+					if (page == null)
+					{
+						break;
+					}
+
+					Assert.False(alreadyReused.Contains(page.Value), "Free space handling returned a page number that has been already allocated. Page number: " + page);
+					Assert.True(freedPages.Remove(page.Value));
+
+					alreadyReused.Add(page.Value);
+
+					tx.Commit();
+				}
+			} while (true);
 		}
 	}
 }

--- a/Voron.Tests/Trees/Iteration.cs
+++ b/Voron.Tests/Trees/Iteration.cs
@@ -15,13 +15,13 @@ namespace Voron.Tests.Trees
 		{
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var iterator = tx.State.Root.Iterate(tx);
+				var iterator = tx.State.Root.Iterate();
 				Assert.False(iterator.Seek(Slice.BeforeAllKeys));
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var iterator = tx.State.Root.Iterate(tx);
+				var iterator = tx.State.Root.Iterate();
 				Assert.False(iterator.Seek(Slice.AfterAllKeys));
 			}
 		}
@@ -37,7 +37,7 @@ namespace Voron.Tests.Trees
 			{
 				for (int i = 0; i < 25; i++)
 				{
-					tx.State.Root.Add(tx, i.ToString("0000"), new MemoryStream(buffer));
+					tx.State.Root.Add(i.ToString("0000"), new MemoryStream(buffer));
 				}
 
 				tx.Commit();
@@ -45,7 +45,7 @@ namespace Voron.Tests.Trees
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var iterator = tx.State.Root.Iterate(tx);
+				var iterator = tx.State.Root.Iterate();
 				Assert.True(iterator.Seek(Slice.BeforeAllKeys));
 
 				var slice = new Slice(SliceOptions.Key);

--- a/Voron.Tests/Trees/MultipleTrees.cs
+++ b/Voron.Tests/Trees/MultipleTrees.cs
@@ -13,14 +13,14 @@ namespace Voron.Tests.Trees
 			{
 				Env.CreateTree(tx, "test");
 
-				Env.CreateTree(tx, "test").Add(tx, "test", StreamFor("abc"));
+				Env.CreateTree(tx, "test").Add("test", StreamFor("abc"));
 
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var stream = tx.Environment.State.GetTree(tx,"test").Read(tx, "test");
+				var stream = tx.Environment.State.GetTree(tx,"test").Read("test");
 				Assert.NotNull(stream);
 
 				tx.Commit();
@@ -34,7 +34,7 @@ namespace Voron.Tests.Trees
 			{
 				Env.CreateTree(tx, "test");
 
-				Env.CreateTree(tx, "test").Add(tx, "test", StreamFor("abc"));
+				Env.CreateTree(tx, "test").Add("test", StreamFor("abc"));
 
 				tx.Commit();
 			}
@@ -42,14 +42,14 @@ namespace Voron.Tests.Trees
 			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
 
-				tx.Environment.State.GetTree(tx,"test").Add(tx, "test2", StreamFor("abc"));
+				tx.Environment.State.GetTree(tx,"test").Add("test2", StreamFor("abc"));
 
 				tx.Commit();
 			}
 
 			using (var tx = Env.NewTransaction(TransactionFlags.Read))
 			{
-				var stream = tx.Environment.State.GetTree(tx,"test").Read(tx, "test2");
+				var stream = tx.Environment.State.GetTree(tx,"test").Read("test2");
 				Assert.NotNull(stream);
 
 				tx.Commit();

--- a/Voron.Tests/Trees/Rebalance.cs
+++ b/Voron.Tests/Trees/Rebalance.cs
@@ -10,18 +10,18 @@ namespace Voron.Tests.Trees
         {
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                tx.State.Root.Add(tx, "1", new MemoryStream(new byte[1472]));
-                tx.State.Root.Add(tx, "2", new MemoryStream(new byte[992]));
-                tx.State.Root.Add(tx, "3", new MemoryStream(new byte[1632]));
-                tx.State.Root.Add(tx, "4", new MemoryStream(new byte[632]));
-                tx.State.Root.Add(tx, "5", new MemoryStream(new byte[824]));
-                tx.State.Root.Delete(tx, "3");
-                tx.State.Root.Add(tx, "6", new MemoryStream(new byte[1096]));
+                tx.State.Root.Add("1", new MemoryStream(new byte[1472]));
+                tx.State.Root.Add("2", new MemoryStream(new byte[992]));
+                tx.State.Root.Add("3", new MemoryStream(new byte[1632]));
+                tx.State.Root.Add("4", new MemoryStream(new byte[632]));
+                tx.State.Root.Add("5", new MemoryStream(new byte[824]));
+                tx.State.Root.Delete("3");
+                tx.State.Root.Add("6", new MemoryStream(new byte[1096]));
 
                 RenderAndShow(tx, 1);
 
-                tx.State.Root.Delete(tx, "6");
-                tx.State.Root.Delete(tx, "4");
+                tx.State.Root.Delete("6");
+                tx.State.Root.Delete("4");
 
                 RenderAndShow(tx,1);
 
@@ -34,18 +34,18 @@ namespace Voron.Tests.Trees
         {
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
             {
-                tx.State.Root.Add(tx, "1", new MemoryStream(new byte[1524]));
-                tx.State.Root.Add(tx, "2", new MemoryStream(new byte[1524]));
-                tx.State.Root.Add(tx, "3", new MemoryStream(new byte[1024]));
-                tx.State.Root.Add(tx, "4", new MemoryStream(new byte[64]));
+                tx.State.Root.Add("1", new MemoryStream(new byte[1524]));
+                tx.State.Root.Add("2", new MemoryStream(new byte[1524]));
+                tx.State.Root.Add("3", new MemoryStream(new byte[1024]));
+                tx.State.Root.Add("4", new MemoryStream(new byte[64]));
 
                 RenderAndShow(tx, 1);
 
-                tx.State.Root.Delete(tx, "2");
+                tx.State.Root.Delete("2");
 
                 RenderAndShow(tx, 1);
 
-				tx.State.Root.Delete(tx, "3");
+				tx.State.Root.Delete("3");
 				RenderAndShow(tx, 1);
 
                 tx.Commit();
@@ -59,30 +59,30 @@ namespace Voron.Tests.Trees
             {
                 for (int i = 0; i < 80; ++i)
                 {
-                    tx.State.Root.Add(tx, string.Format("{0}1", i), new MemoryStream(new byte[1472]));
-                    tx.State.Root.Add(tx, string.Format("{0}2", i), new MemoryStream(new byte[992]));
-                    tx.State.Root.Add(tx, string.Format("{0}3", i), new MemoryStream(new byte[1632]));
-                    tx.State.Root.Add(tx, string.Format("{0}4", i), new MemoryStream(new byte[632]));
-                    tx.State.Root.Add(tx, string.Format("{0}5", i), new MemoryStream(new byte[824]));
-                    tx.State.Root.Add(tx, string.Format("{0}6", i), new MemoryStream(new byte[1096]));
-                    tx.State.Root.Add(tx, string.Format("{0}7", i), new MemoryStream(new byte[2048]));
-                    tx.State.Root.Add(tx, string.Format("{0}8", i), new MemoryStream(new byte[1228]));
-                    tx.State.Root.Add(tx, string.Format("{0}9", i), new MemoryStream(new byte[8192]));
+                    tx.State.Root.Add(string.Format("{0}1", i), new MemoryStream(new byte[1472]));
+                    tx.State.Root.Add(string.Format("{0}2", i), new MemoryStream(new byte[992]));
+                    tx.State.Root.Add(string.Format("{0}3", i), new MemoryStream(new byte[1632]));
+                    tx.State.Root.Add(string.Format("{0}4", i), new MemoryStream(new byte[632]));
+                    tx.State.Root.Add(string.Format("{0}5", i), new MemoryStream(new byte[824]));
+                    tx.State.Root.Add(string.Format("{0}6", i), new MemoryStream(new byte[1096]));
+                    tx.State.Root.Add(string.Format("{0}7", i), new MemoryStream(new byte[2048]));
+                    tx.State.Root.Add(string.Format("{0}8", i), new MemoryStream(new byte[1228]));
+                    tx.State.Root.Add(string.Format("{0}9", i), new MemoryStream(new byte[8192]));
                 }
 
                 RenderAndShow(tx, 1);
 
                 for (int i = 79; i >= 0; --i)
                 {
-                    tx.State.Root.Delete(tx, string.Format("{0}1", i));
-                    tx.State.Root.Delete(tx, string.Format("{0}2", i));
-                    tx.State.Root.Delete(tx, string.Format("{0}3", i));
-                    tx.State.Root.Delete(tx, string.Format("{0}4", i));
-                    tx.State.Root.Delete(tx, string.Format("{0}5", i));
-                    tx.State.Root.Delete(tx, string.Format("{0}6", i));
-                    tx.State.Root.Delete(tx, string.Format("{0}7", i));
-                    tx.State.Root.Delete(tx, string.Format("{0}8", i));
-                    tx.State.Root.Delete(tx, string.Format("{0}9", i));
+                    tx.State.Root.Delete(string.Format("{0}1", i));
+                    tx.State.Root.Delete(string.Format("{0}2", i));
+                    tx.State.Root.Delete(string.Format("{0}3", i));
+                    tx.State.Root.Delete(string.Format("{0}4", i));
+                    tx.State.Root.Delete(string.Format("{0}5", i));
+                    tx.State.Root.Delete(string.Format("{0}6", i));
+                    tx.State.Root.Delete(string.Format("{0}7", i));
+                    tx.State.Root.Delete(string.Format("{0}8", i));
+                    tx.State.Root.Delete(string.Format("{0}9", i));
                 }
 
                 tx.Commit();

--- a/Voron.Tests/Trees/Updates.cs
+++ b/Voron.Tests/Trees/Updates.cs
@@ -15,7 +15,7 @@ namespace Voron.Tests.Trees
 
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "a", new MemoryStream(buffer));
+				tx.State.Root.Add("a", new MemoryStream(buffer));
 
 				tx.Commit();
 			}
@@ -32,7 +32,7 @@ namespace Voron.Tests.Trees
 
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "a", new MemoryStream(buffer));
+				tx.State.Root.Add("a", new MemoryStream(buffer));
 
 				tx.Commit();
 			}
@@ -51,8 +51,8 @@ namespace Voron.Tests.Trees
 		{
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "test", StreamFor("1"));
-				tx.State.Root.Add(tx, "test", StreamFor("2"));
+				tx.State.Root.Add("test", StreamFor("1"));
+				tx.State.Root.Add("test", StreamFor("2"));
 
 				var readKey = ReadKey(tx, "test");
 				Assert.Equal("test", readKey.Item1);
@@ -65,9 +65,9 @@ namespace Voron.Tests.Trees
 		{
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "test/1", StreamFor("1"));
-				tx.State.Root.Add(tx, "test/2", StreamFor("2"));
-				tx.State.Root.Add(tx, "test/1", StreamFor("3"));
+				tx.State.Root.Add("test/1", StreamFor("1"));
+				tx.State.Root.Add("test/2", StreamFor("2"));
+				tx.State.Root.Add("test/1", StreamFor("3"));
 
 				var readKey = ReadKey(tx, "test/1");
 				Assert.Equal("test/1", readKey.Item1);
@@ -85,9 +85,9 @@ namespace Voron.Tests.Trees
 		{
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "test/1", StreamFor("1"));
-				tx.State.Root.Add(tx, "test/2", StreamFor("2"));
-				tx.State.Root.Add(tx, "test/2", StreamFor("3"));
+				tx.State.Root.Add("test/1", StreamFor("1"));
+				tx.State.Root.Add("test/2", StreamFor("2"));
+				tx.State.Root.Add("test/2", StreamFor("3"));
 
 				var readKey = ReadKey(tx, "test/1");
 				Assert.Equal("test/1", readKey.Item1);
@@ -106,10 +106,10 @@ namespace Voron.Tests.Trees
 		{
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "test", StreamFor("1"));
+				tx.State.Root.Add("test", StreamFor("1"));
 				Assert.NotNull(ReadKey(tx, "test"));
 
-				tx.State.Root.Delete(tx, "test");
+				tx.State.Root.Delete("test");
 				Assert.Null(ReadKey(tx, "test"));
 			}
 		}
@@ -119,11 +119,11 @@ namespace Voron.Tests.Trees
 		{
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "test/1", StreamFor("1"));
-				tx.State.Root.Add(tx, "test/2", StreamFor("1"));
+				tx.State.Root.Add("test/1", StreamFor("1"));
+				tx.State.Root.Add("test/2", StreamFor("1"));
 				Assert.NotNull(ReadKey(tx, "test/2"));
 
-				tx.State.Root.Delete(tx, "test/2");
+				tx.State.Root.Delete("test/2");
 				Assert.Null(ReadKey(tx, "test/2"));
 				Assert.NotNull(ReadKey(tx, "test/1"));
 			}
@@ -134,11 +134,11 @@ namespace Voron.Tests.Trees
 		{
             using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 			{
-				tx.State.Root.Add(tx, "test/1", StreamFor("1"));
-				tx.State.Root.Add(tx, "test/2", StreamFor("1"));
+				tx.State.Root.Add("test/1", StreamFor("1"));
+				tx.State.Root.Add("test/2", StreamFor("1"));
 				Assert.NotNull(ReadKey(tx, "test/1"));
 
-				tx.State.Root.Delete(tx, "test/1");
+				tx.State.Root.Delete("test/1");
 				Assert.Null(ReadKey(tx, "test/1"));
 				Assert.NotNull(ReadKey(tx, "test/2"));
 			}

--- a/Voron.Tests/Util/StreamExtensions.cs
+++ b/Voron.Tests/Util/StreamExtensions.cs
@@ -57,7 +57,6 @@ namespace Voron.Tests
             return BitConverter.ToInt32(buffer, 0);
         }
 
-#if !SILVERLIGHT
         public static string ReadString(this Stream stream)
         {
             return ReadString(stream, Encoding.UTF8);
@@ -83,7 +82,6 @@ namespace Voron.Tests
 
             return encoding.GetString(buffer);
         }
-#endif
 
         public static void Write(this Stream stream, string value)
         {

--- a/Voron.Tests/Voron.Tests.csproj
+++ b/Voron.Tests/Voron.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Voron.Tests</RootNamespace>
     <AssemblyName>Voron.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -63,6 +63,7 @@
   <ItemGroup>
     <Compile Include="Backups\Full.cs" />
     <Compile Include="Backups\Incremental.cs" />
+    <Compile Include="Bugs\AccessViolationWithIteratorUsage.cs" />
     <Compile Include="Bugs\ChecksumMismatchAfterRecovery.cs" />
     <Compile Include="Bugs\MemoryAccess.cs" />
     <Compile Include="Bugs\FlushingToDataFile.cs" />
@@ -74,22 +75,23 @@
     <Compile Include="Bugs\PageTableIssue.cs" />
     <Compile Include="Bugs\RecoveryMultipleJournals.cs" />
     <Compile Include="Bugs\RecoveryWithManualFlush.cs" />
-    <Compile Include="Bugs\RequiredPrefixWithSeekBeforeAllKeys.cs" />
     <Compile Include="Bugs\Snapshots.cs" />
     <Compile Include="Bugs\Deletes.cs" />
     <Compile Include="Bugs\EmptyTree.cs" />
     <Compile Include="Bugs\PageSplitter.cs" />
     <Compile Include="Bugs\Recovery.cs" />
     <Compile Include="Bugs\InvalidReleasesOfScratchPages.cs" />
+    <Compile Include="Bugs\MultiReads.cs" />
+    <Compile Include="Bugs\Iterating.cs" />
     <Compile Include="Bugs\TreeRebalancer.cs" />
     <Compile Include="Bugs\Versioning.cs" />
     <Compile Include="Bugs\UpdateLastItem.cs" />
     <Compile Include="DebugJournalTest.cs" />
     <Compile Include="Journal\BasicActions.cs" />
     <Compile Include="Journal\EdgeCases.cs" />
-    <Compile Include="Journal\LogShipping.cs" />
     <Compile Include="Journal\Mvcc.cs" />
     <Compile Include="Journal\UncommittedTransactions.cs" />
+    <Compile Include="MultiTreeSize.cs" />
     <Compile Include="MultiValueTree.cs" />
     <Compile Include="Optimizations\Writes.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -98,6 +100,8 @@
     <Compile Include="Storage\Concurrency.cs" />
     <Compile Include="Storage\Files.cs" />
     <Compile Include="Storage\FreeScratchPages.cs" />
+    <Compile Include="Storage\Increments.cs" />
+    <Compile Include="Storage\InitialSize.cs" />
     <Compile Include="Storage\MemoryMapWithoutBackingPagerTest.cs" />
     <Compile Include="Storage\MultiTransactions.cs" />
     <Compile Include="Storage\Pagers.cs" />
@@ -119,7 +123,6 @@
     <Compile Include="Util\CrcTests.cs" />
     <Compile Include="Util\ImmutableAppendOnlyTests.cs" />
     <Compile Include="Util\StreamExtensions.cs" />
-    <Compile Include="Util\UnmanagedVectorMemoryStreamTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Voron\Voron.csproj">
@@ -141,7 +144,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="RavenDB.snk" />

--- a/Voron.Tests/Voron.Tests.csproj
+++ b/Voron.Tests/Voron.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Bugs\PageTableIssue.cs" />
     <Compile Include="Bugs\RecoveryMultipleJournals.cs" />
     <Compile Include="Bugs\RecoveryWithManualFlush.cs" />
+    <Compile Include="Bugs\RequiredPrefixWithSeekBeforeAllKeys.cs" />
     <Compile Include="Bugs\Snapshots.cs" />
     <Compile Include="Bugs\Deletes.cs" />
     <Compile Include="Bugs\EmptyTree.cs" />

--- a/Voron.Tests/Voron.Tests.csproj
+++ b/Voron.Tests/Voron.Tests.csproj
@@ -53,12 +53,10 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
-
     <Reference Include="xunit">
       <HintPath>..\..\SharedLibs\xunit\xunit.dll</HintPath>
     </Reference>
     <Reference Include="xunit.extensions">
-
       <HintPath>..\..\SharedLibs\xunit\xunit.extensions.dll</HintPath>
     </Reference>
   </ItemGroup>
@@ -96,6 +94,7 @@
     <Compile Include="Storage\Batches.cs" />
     <Compile Include="Storage\BigValue.cs" />
     <Compile Include="Storage\Concurrency.cs" />
+    <Compile Include="Storage\Files.cs" />
     <Compile Include="Storage\FreeScratchPages.cs" />
     <Compile Include="Storage\MemoryMapWithoutBackingPagerTest.cs" />
     <Compile Include="Storage\MultiTransactions.cs" />

--- a/Voron/Debugging/DebugActionType.cs
+++ b/Voron/Debugging/DebugActionType.cs
@@ -6,6 +6,7 @@
 		Delete,
 		MultiAdd,
 		MultiDelete,
-		CreateTree,			
+		CreateTree,
+		Increment	
 	}
 }

--- a/Voron/Debugging/EnvironmentStats.cs
+++ b/Voron/Debugging/EnvironmentStats.cs
@@ -6,5 +6,7 @@
         public long FreePagesOverhead;
         public long RootPages;
         public long UnallocatedPagesAtEndOfFile;
+        public long UsedDataFileSizeInBytes;
+        public long AllocatedDataFileSizeInBytes;
     }
 }

--- a/Voron/Debugging/EnvironmentStats.cs
+++ b/Voron/Debugging/EnvironmentStats.cs
@@ -1,24 +1,11 @@
 ﻿namespace Voron.Debugging
 {
-<<<<<<< HEAD
     public class EnvironmentStats
     {
-        public long FreePages;
         public long FreePagesOverhead;
         public long RootPages;
         public long UnallocatedPagesAtEndOfFile;
         public long UsedDataFileSizeInBytes;
         public long AllocatedDataFileSizeInBytes;
     }
-=======
-	public class EnvironmentStats
-	{
-		public long FreePages;
-		public long FreePagesOverhead;
-		public long RootPages;
-		public long UnallocatedPagesAtEndOfFile;
-		public long UsedDataFileSizeInBytes;
-		public long AllocatedDataFileSizeInBytes;
-	}
->>>>>>> e45804f0d5ace9c91417184e68593aafb1774486
 }

--- a/Voron/Impl/Backup/BackupMethods.cs
+++ b/Voron/Impl/Backup/BackupMethods.cs
@@ -3,15 +3,15 @@
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
-
 namespace Voron.Impl.Backup
 {
 	public class BackupMethods
 	{
-		public const string Filename = "RavenDB.Voron.Backup";
+        public const string Filename = "RavenDB.Voron.Backup";
 
 		public static FullBackup Full = new FullBackup();
 
 		public static IncrementalBackup Incremental = new IncrementalBackup();
+
 	}
 }

--- a/Voron/Impl/Backup/IncrementalBackup.cs
+++ b/Voron/Impl/Backup/IncrementalBackup.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading.Tasks;
 using Voron.Impl.Journal;
 using Voron.Impl.Paging;
 using Voron.Trees;
@@ -19,8 +20,22 @@ namespace Voron.Impl.Backup
 {
     public unsafe class IncrementalBackup
     {
-        public long ToFile(StorageEnvironment env, string backupPath, CompressionLevel compression = CompressionLevel.Optimal)
+        public class IncrementalRestorePaths
         {
+            private string _journalLocation;
+            public string DatabaseLocation { get; set; }
+            public string JournalLocation
+            {
+                get { return _journalLocation ?? DatabaseLocation; }
+                set { _journalLocation = value; }
+            }
+        }
+
+        public long ToFile(StorageEnvironment env, string backupPath, CompressionLevel compression = CompressionLevel.Optimal,
+			Action<string> infoNotify = null)
+        {
+			infoNotify = infoNotify ?? (s => { });
+
             if (env.Options.IncrementalBackupEnabled == false)
                 throw new InvalidOperationException("Incremental backup is disabled for this storage");
 
@@ -29,31 +44,31 @@ namespace Voron.Impl.Backup
             var copier = new DataCopier(AbstractPager.PageSize * 16);
             var backupSuccess = true;
 
-            IncrementalBackupInfo backupInfo;
             long lastWrittenLogPage = -1;
             long lastWrittenLogFile = -1;
 
-            using (var txw = env.NewTransaction(TransactionFlags.ReadWrite))
+            using (var file = new FileStream(backupPath, FileMode.Create))
+            using (var package = new ZipArchive(file, ZipArchiveMode.Create))
             {
-                backupInfo = env.HeaderAccessor.Get(ptr => ptr->IncrementalBackup);
-
-                if (env.Journal.CurrentFile != null)
+                IncrementalBackupInfo backupInfo;
+                using (var txw = env.NewTransaction(TransactionFlags.ReadWrite))
                 {
-                    lastWrittenLogFile = env.Journal.CurrentFile.Number;
-                    lastWrittenLogPage = env.Journal.CurrentFile.WritePagePosition;
+                    backupInfo = env.HeaderAccessor.Get(ptr => ptr->IncrementalBackup);
+
+                    if (env.Journal.CurrentFile != null)
+                    {
+                        lastWrittenLogFile = env.Journal.CurrentFile.Number;
+                        lastWrittenLogPage = env.Journal.CurrentFile.WritePagePosition;
+                    }
+
+                    // txw.Commit(); intentionally not committing
                 }
 
-                // txw.Commit(); intentionally not committing
-            }
-
-            using (env.NewTransaction(TransactionFlags.Read))
-            {
-                var usedJournals = new List<JournalFile>();
-
-                try
+                using (env.NewTransaction(TransactionFlags.Read))
                 {
-                    using (var file = new FileStream(backupPath, FileMode.Create))
-                    using (var package = new ZipArchive(file, ZipArchiveMode.Create))
+                    var usedJournals = new List<JournalFile>();
+
+                    try
                     {
                         long lastBackedUpPage = -1;
                         long lastBackedUpFile = -1;
@@ -65,6 +80,8 @@ namespace Voron.Impl.Backup
 
                         for (var journalNum = firstJournalToBackup; journalNum <= backupInfo.LastCreatedJournal; journalNum++)
                         {
+                            var num = journalNum;
+
                             var journalFile = env.Journal.Files.FirstOrDefault(x => x.Number == journalNum); // first check journal files currently being in use
                             if (journalFile == null)
                             {
@@ -72,9 +89,6 @@ namespace Voron.Impl.Backup
                                 using (var pager = env.Options.OpenJournalPager(journalNum))
                                 {
                                     journalSize = Utils.NearestPowerOfTwo(pager.NumberOfAllocatedPages * AbstractPager.PageSize);
-                                    if (journalSize >= env.Options.MaxLogFileSize) // can't set for more than the max log file size
-                                        throw new InvalidOperationException("Recovered journal size is " + journalSize +
-                                                                            ", while the maximum journal size can be " + env.Options.MaxLogFileSize);
                                 }
 
                                 journalFile = new JournalFile(env.Options.CreateJournalWriter(journalNum, journalSize), journalNum);
@@ -104,6 +118,8 @@ namespace Voron.Impl.Backup
                             using (var stream = part.Open())
                             {
                                 copier.ToStream(journalFile, startBackupAt, pagesToCopy, stream);
+                                infoNotify(string.Format("Voron Incr copy journal number {0}", num));
+
                             }
 
                             lastBackedUpFile = journalFile.Number;
@@ -124,34 +140,34 @@ namespace Voron.Impl.Backup
                         //Debug.Assert(lastBackedUpPage != -1);
 
                         env.HeaderAccessor.Modify(header =>
-                            {
-                                header->IncrementalBackup.LastBackedUpJournal = lastBackedUpFile;
-                                header->IncrementalBackup.LastBackedUpJournalPage = lastBackedUpPage;
-                            });
-                    }
-                }
-                catch (Exception)
-                {
-                    backupSuccess = false;
-                    throw;
-                }
-                finally
-                {
-                    foreach (var file in usedJournals)
-                    {
-                        if (backupSuccess) // if backup succeeded we can remove journals
                         {
-                            if (file.Number != lastWrittenLogFile) // prevent deletion of the current journal
-                            {
-                                file.DeleteOnClose = true;
-                            }
-                        }
-
-                        file.Release();
+                            header->IncrementalBackup.LastBackedUpJournal = lastBackedUpFile;
+                            header->IncrementalBackup.LastBackedUpJournalPage = lastBackedUpPage;
+                        });
                     }
-                }
+                    catch (Exception)
+                    {
+                        backupSuccess = false;
+                        throw;
+                    }
+                    finally
+                    {
+                        foreach (var jrnl in usedJournals)
+                        {
+                            if (backupSuccess) // if backup succeeded we can remove journals
+                            {
+                                if (jrnl.Number < lastWrittenLogFile) // prevent deletion of the current journal and journals with a greater number
+                                {
+                                    jrnl.DeleteOnClose = true;
+                                }
+                            }
 
-                return numberOfBackedUpPages;
+                            jrnl.Release();
+                        }
+                    }
+                    infoNotify(string.Format("Voron Incr Backup total {0} pages", numberOfBackedUpPages));
+                    return numberOfBackedUpPages;
+                }
             }
         }
 
@@ -169,7 +185,7 @@ namespace Voron.Impl.Backup
             options.OwnsPagers = ownsPagers;
         }
 
-        private void Restore(StorageEnvironment env, string backupPath)
+        private void Restore(StorageEnvironment env, string singleBackupFile)
         {
             using (env.Journal.Applicator.TakeFlushingLock())
             {
@@ -180,107 +196,124 @@ namespace Voron.Impl.Backup
                         env.FlushLogToDataFile(txw);
                     }
 
-                    List<string> journalNames;
-
-                    using (var package = ZipFile.Open(backupPath, ZipArchiveMode.Read))
+                    using (var package = ZipFile.Open(singleBackupFile, ZipArchiveMode.Read))
                     {
-                        journalNames = package.Entries.Select(x => x.Name).ToList();
-                    }
+                        if (package.Entries.Count == 0)
+                            return;
 
-                    if (journalNames.Count == 0)
-                        return;
+                        var toDispose = new List<IDisposable>();
 
-                    var tempDir = Directory.CreateDirectory(Path.GetTempPath() + Guid.NewGuid()).FullName;
-                    var toDispose = new List<IDisposable>();
+						var tempDir = Directory.CreateDirectory(Path.GetTempPath() + Guid.NewGuid()).FullName;
 
-                    try
-                    {
-                        ZipFile.ExtractToDirectory(backupPath, tempDir);
-
-                        TransactionHeader* lastTxHeader = null;
-
-                        var pagesToWrite = new Dictionary<long, Func<Page>>();
-
-                        long journalNumber = -1;
-                        foreach (var journalName in journalNames)
+                        try
                         {
-                            var pager = new Win32MemoryMapPager(Path.Combine(tempDir, journalName));
-                            toDispose.Add(pager);
+                            TransactionHeader* lastTxHeader = null;
+                            var pagesToWrite = new Dictionary<long, Func<Page>>();
 
-
-                            if (long.TryParse(journalName.Replace(".journal", string.Empty), out journalNumber) == false)
+                            long journalNumber = -1;
+                            foreach (var entry in package.Entries)
                             {
-                                throw new InvalidOperationException("Cannot parse journal file number");
+                                switch (Path.GetExtension(entry.Name))
+                                {
+                                    case ".journal":
+
+										var jounalFileName = Path.Combine(tempDir, entry.Name);
+                                        using (var output = new FileStream(jounalFileName, FileMode.Create))
+                                        using (var input = entry.Open())
+                                        {
+                                            output.Position = output.Length;
+                                            input.CopyTo(output);
+                                        }
+
+                                        var pager = new Win32MemoryMapPager(jounalFileName);
+                                        toDispose.Add(pager);
+
+                                        if (long.TryParse(Path.GetFileNameWithoutExtension(entry.Name), out journalNumber) == false)
+                                        {
+                                            throw new InvalidOperationException("Cannot parse journal file number");
+                                        }
+
+										var recoveryPager = new Win32MemoryMapPager(Path.Combine(tempDir, StorageEnvironmentOptions.JournalRecoveryName(journalNumber)));
+                                        toDispose.Add(recoveryPager);
+
+                                        var reader = new JournalReader(pager, recoveryPager, 0, lastTxHeader);
+
+                                        while (reader.ReadOneTransaction(env.Options))
+                                        {
+                                            lastTxHeader = reader.LastTransactionHeader;
+                                        }
+
+                                        foreach (var translation in reader.TransactionPageTranslation)
+                                        {
+                                            var pageInJournal = translation.Value.JournalPos;
+                                            pagesToWrite[translation.Key] = () => recoveryPager.Read(pageInJournal);
+                                        }
+
+                                        break;
+                                    default:
+                                        throw new InvalidOperationException("Unknown file, cannot restore: " + entry);
+                                }
                             }
 
-                            var recoveryPager = new Win32MemoryMapPager(Path.Combine(tempDir, StorageEnvironmentOptions.JournalRecoveryName(journalNumber)));
-                            toDispose.Add(recoveryPager);
+                            var sortedPages = pagesToWrite.OrderBy(x => x.Key)
+                                .Select(x => x.Value())
+                                .ToList();
 
-                            var reader = new JournalReader(pager, recoveryPager, 0, lastTxHeader);
+                            var last = sortedPages.Last();
 
-                            while (reader.ReadOneTransaction(env.Options))
+                            env.Options.DataPager.EnsureContinuous(txw, last.PageNumber,
+                                last.IsOverflow
+                                    ? env.Options.DataPager.GetNumberOfOverflowPages(
+                                        last.OverflowSize)
+                                    : 1);
+
+                            foreach (var page in sortedPages)
                             {
-                                lastTxHeader = reader.LastTransactionHeader;
+                                env.Options.DataPager.Write(page);
                             }
 
-                            foreach (var translation in reader.TransactionPageTranslation)
+                            env.Options.DataPager.Sync();
+
+                            txw.State.Root = Tree.Open(txw, env._sliceComparer, &lastTxHeader->Root);
+                            txw.State.FreeSpaceRoot = Tree.Open(txw, env._sliceComparer, &lastTxHeader->FreeSpace);
+
+                            txw.State.FreeSpaceRoot.Name = Constants.FreeSpaceTreeName;
+                            txw.State.Root.Name = Constants.RootTreeName;
+
+                            txw.State.NextPageNumber = lastTxHeader->LastPageNumber + 1;
+
+                            env.Journal.Clear(txw);
+
+                            txw.Commit();
+
+                            env.HeaderAccessor.Modify(header =>
                             {
-                                var pageInJournal = translation.Value.JournalPos;
-                                pagesToWrite[translation.Key] = () => recoveryPager.Read(pageInJournal);
-                            }
+                                header->TransactionId = lastTxHeader->TransactionId;
+                                header->LastPageNumber = lastTxHeader->LastPageNumber;
+
+                                header->Journal.LastSyncedJournal = journalNumber;
+                                header->Journal.LastSyncedTransactionId = lastTxHeader->TransactionId;
+
+                                header->Root = lastTxHeader->Root;
+                                header->FreeSpace = lastTxHeader->FreeSpace;
+
+                                header->Journal.CurrentJournal = journalNumber + 1;
+                                header->Journal.JournalFilesCount = 0;
+                            });
                         }
-
-                        var sortedPages = pagesToWrite.OrderBy(x => x.Key)
-                                                      .Select(x => x.Value())
-                                                      .ToList();
-
-                        var last = sortedPages.Last();
-
-                        env.Options.DataPager.EnsureContinuous(txw, last.PageNumber,
-                                                        last.IsOverflow
-                                                            ? env.Options.DataPager.GetNumberOfOverflowPages(
-                                                                last.OverflowSize)
-                                                            : 1);
-
-                        foreach (var page in sortedPages)
+                        finally
                         {
-                            env.Options.DataPager.Write(page);
+                            toDispose.ForEach(x => x.Dispose());
+
+	                        try
+	                        {
+								Directory.Delete(tempDir, true);
+	                        }
+	                        catch (Exception)
+	                        {
+								// just temp dir - ignore it
+	                        }
                         }
-
-                        env.Options.DataPager.Sync();
-
-                        txw.State.Root = Tree.Open(txw, env._sliceComparer, &lastTxHeader->Root);
-                        txw.State.FreeSpaceRoot = Tree.Open(txw, env._sliceComparer, &lastTxHeader->FreeSpace);
-
-                        txw.State.FreeSpaceRoot.Name = Constants.FreeSpaceTreeName;
-                        txw.State.Root.Name = Constants.RootTreeName;
-
-                        txw.State.NextPageNumber = lastTxHeader->LastPageNumber + 1;
-
-                        env.Journal.Clear(txw);
-
-                        txw.Commit();
-
-                        env.HeaderAccessor.Modify(header =>
-                        {
-                            header->TransactionId = lastTxHeader->TransactionId;
-                            header->LastPageNumber = lastTxHeader->LastPageNumber;
-
-                            header->Journal.LastSyncedJournal = journalNumber;
-                            header->Journal.LastSyncedTransactionId = lastTxHeader->TransactionId;
-
-                            header->Root = lastTxHeader->Root;
-                            header->FreeSpace = lastTxHeader->FreeSpace;
-
-                            header->Journal.CurrentJournal = journalNumber + 1;
-                            header->Journal.JournalFilesCount = 0;
-                        });
-                    }
-                    finally
-                    {
-                        toDispose.ForEach(x => x.Dispose());
-
-                        Directory.Delete(tempDir, true);
                     }
                 }
             }

--- a/Voron/Impl/Backup/VoronBackupUtil.cs
+++ b/Voron/Impl/Backup/VoronBackupUtil.cs
@@ -1,0 +1,29 @@
+﻿using System.Diagnostics;
+using System.IO.Compression;
+using Voron.Impl.FileHeaders;
+using Voron.Util;
+
+namespace Voron.Impl.Backup
+{
+    internal static unsafe class VoronBackupUtil
+    {
+        internal static void CopyHeaders(CompressionLevel compression, ZipArchive package, DataCopier copier, StorageEnvironmentOptions storageEnvironmentOptions)
+        {
+            foreach (var headerFileName in HeaderAccessor.HeaderFileNames)
+            {
+                var header = stackalloc FileHeader[1];
+
+                if (!storageEnvironmentOptions.ReadHeader(headerFileName, header))
+                    continue;
+
+                var headerPart = package.CreateEntry(headerFileName, compression);
+                Debug.Assert(headerPart != null);
+
+                using (var headerStream = headerPart.Open())
+                {
+                    copier.ToStream((byte*)header, sizeof(FileHeader), headerStream);
+                }
+            }
+        }
+    }
+}

--- a/Voron/Impl/Constants.cs
+++ b/Voron/Impl/Constants.cs
@@ -21,7 +21,7 @@ namespace Voron.Impl
 		public static int PageNumberSize = sizeof(long);
 
 		public static int NodeOffsetSize = sizeof(ushort);
-	    public const int CurrentVersion = 0x00010009;
+		public const int CurrentVersion = 2;
 
 		public const string RootTreeName = "Root";
 		public const string FreeSpaceTreeName = "Free Space";

--- a/Voron/Impl/FileHeaders/HeaderAccessor.cs
+++ b/Voron/Impl/FileHeaders/HeaderAccessor.cs
@@ -72,7 +72,8 @@ namespace Voron.Impl.FileHeaders
 			}
 
 			if (f1->Version != Constants.CurrentVersion)
-				throw new InvalidDataException("This is a db file for version " + f1->Version + ", which is not compatible with the current version " + Constants.CurrentVersion);
+				throw new InvalidDataException("This is a db file for version " + f1->Version + ", which is not compatible with the current version " + Constants.CurrentVersion + Environment.NewLine +
+					"Error at " + _env.Options.BasePath);
 
 			if (f1->TransactionId < 0)
 				throw new InvalidDataException("The transaction number cannot be negative");

--- a/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -16,7 +16,7 @@ namespace Voron.Impl.FreeSpace
 		    if (tx.State.FreeSpaceRoot.State.EntriesCount == 0)
 		        return null;
 
-			using (var it = tx.State.FreeSpaceRoot.Iterate(tx))
+			using (var it = tx.State.FreeSpaceRoot.Iterate())
 			{
 				if (it.Seek(Slice.BeforeAllKeys) == false)
 					return null;
@@ -76,7 +76,7 @@ namespace Voron.Impl.FreeSpace
 					{
 						foreach (var section in sections)
 						{
-							tx.State.FreeSpaceRoot.Delete(tx, section);
+							tx.State.FreeSpaceRoot.Delete(section);
 						}
 
 						return startSectionId * NumberOfPagesInSection;
@@ -84,7 +84,7 @@ namespace Voron.Impl.FreeSpace
 
 					var nextSectionId = currentSectionId + 1;
 					var nextId = new Slice(EndianBitConverter.Big.GetBytes(nextSectionId));
-					var read = tx.State.FreeSpaceRoot.Read(tx, nextId);
+					var read = tx.State.FreeSpaceRoot.Read(nextId);
 					if (read == null)
 					{
 						//not a following next section
@@ -104,7 +104,7 @@ namespace Voron.Impl.FreeSpace
 					//mark selected bits to false
 					if (next.SetCount == numberOfExtraBitsNeeded)
 					{
-						tx.State.FreeSpaceRoot.Delete(tx, nextId);
+						tx.State.FreeSpaceRoot.Delete(nextId);
 					}
 					else
 					{
@@ -112,12 +112,12 @@ namespace Voron.Impl.FreeSpace
 						{
 							next.Set(i, false);
 						}
-						tx.State.FreeSpaceRoot.Add(tx, nextId, next.ToStream());
+						tx.State.FreeSpaceRoot.Add(nextId, next.ToStream());
 					}
 
 					foreach (var section in sections)
 					{
-						tx.State.FreeSpaceRoot.Delete(tx, section);
+						tx.State.FreeSpaceRoot.Delete(section);
 					}
 
 					return startSectionId * NumberOfPagesInSection;
@@ -194,7 +194,7 @@ namespace Voron.Impl.FreeSpace
 
 			if (current.SetCount == num)
 			{
-				tx.State.FreeSpaceRoot.Delete(tx, it.CurrentKey);
+				tx.State.FreeSpaceRoot.Delete(it.CurrentKey);
 			}
 			else
 			{
@@ -203,7 +203,7 @@ namespace Voron.Impl.FreeSpace
 					current.Set(i + start, false);
 				}
 
-				tx.State.FreeSpaceRoot.Add(tx, it.CurrentKey, current.ToStream());
+				tx.State.FreeSpaceRoot.Add(it.CurrentKey, current.ToStream());
 			}
 
 			return true;
@@ -219,7 +219,7 @@ namespace Voron.Impl.FreeSpace
 			var nextSectionId = currentSectionId + 1;
 
 			var nextId = new Slice(EndianBitConverter.Big.GetBytes(nextSectionId));
-			var read = tx.State.FreeSpaceRoot.Read(tx, nextId);
+			var read = tx.State.FreeSpaceRoot.Read(nextId);
 			if (read == null)
 				return false;
 
@@ -231,7 +231,7 @@ namespace Voron.Impl.FreeSpace
 
 			if (next.SetCount == nextRange)
 			{
-				tx.State.FreeSpaceRoot.Delete(tx, nextId);
+				tx.State.FreeSpaceRoot.Delete(nextId);
 			}
 			else
 			{
@@ -239,12 +239,12 @@ namespace Voron.Impl.FreeSpace
 				{
 					next.Set(i, false);
 				}
-				tx.State.FreeSpaceRoot.Add(tx, nextId, next.ToStream());
+				tx.State.FreeSpaceRoot.Add(nextId, next.ToStream());
 			}
 
 			if (current.SetCount == currentRange)
 			{
-				tx.State.FreeSpaceRoot.Delete(tx, it.CurrentKey);
+				tx.State.FreeSpaceRoot.Delete(it.CurrentKey);
 			}
 			else
 			{
@@ -252,7 +252,7 @@ namespace Voron.Impl.FreeSpace
 				{
 					current.Set(NumberOfPagesInSection - 1 - i, false);
 				}
-				tx.State.FreeSpaceRoot.Add(tx, nextId, next.ToStream());
+				tx.State.FreeSpaceRoot.Add(nextId, next.ToStream());
 			}
 
 
@@ -262,17 +262,17 @@ namespace Voron.Impl.FreeSpace
 
 		public List<long> AllPages(Transaction tx)
 		{
-			return tx.State.FreeSpaceRoot.AllPages(tx);
+			return tx.State.FreeSpaceRoot.AllPages();
 		}
 
 		public void FreePage(Transaction tx, long pageNumber)
 		{
 			var section = pageNumber / NumberOfPagesInSection;
 			var sectionKey = new Slice(EndianBitConverter.Big.GetBytes(section));
-			var result = tx.State.FreeSpaceRoot.Read(tx, sectionKey);
+			var result = tx.State.FreeSpaceRoot.Read(sectionKey);
 			var sba = result == null ? new StreamBitArray() : new StreamBitArray(result.Reader);
 			sba.Set((int)(pageNumber % NumberOfPagesInSection), true);
-			tx.State.FreeSpaceRoot.Add(tx, sectionKey, sba.ToStream());
+			tx.State.FreeSpaceRoot.Add(sectionKey, sba.ToStream());
 		}
 	}
 }

--- a/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -7,14 +7,6 @@ namespace Voron.Impl.FreeSpace
 	public class FreeSpaceHandling : IFreeSpaceHandling
 	{
 		internal const int NumberOfPagesInSection = 256 * 8; // 256 bytes, 8 bits per byte = 2,048 - each section 8 MB in size
-		private readonly StorageEnvironment _env;
-		private readonly Slice _freePagesCount;
-
-		public FreeSpaceHandling(StorageEnvironment env)
-		{
-			_freePagesCount = new Slice(EndianBitConverter.Big.GetBytes(long.MinValue));
-			_env = env;
-		}
 
 		public long? TryAllocateFromFreeSpace(Transaction tx, int num)
 		{
@@ -51,7 +43,7 @@ namespace Voron.Impl.FreeSpace
 				var stream = it.CreateReaderForCurrent();
 				{
 					var current = new StreamBitArray(stream);
-					var currentSectionId = it.CurrentKey.ToInt64();
+				    var currentSectionId = it.CurrentKey.CreateReader().ReadBigEndianInt64();
 
 					//need to find full free pages
 					if (current.SetCount < NumberOfPagesInSection)
@@ -150,7 +142,7 @@ namespace Voron.Impl.FreeSpace
 			    var stream = it.CreateReaderForCurrent();
 				{
 					var current = new StreamBitArray(stream);
-					var currentSectionId = it.CurrentKey.ToInt64();
+				    var currentSectionId = it.CurrentKey.CreateReader().ReadBigEndianInt64();
 
 					long? page;
 					if (current.SetCount < num)
@@ -266,17 +258,6 @@ namespace Voron.Impl.FreeSpace
 
 			result = currentSectionId * NumberOfPagesInSection + currentRange;
 			return true;
-		}
-
-		public long GetFreePageCount()
-		{
-			using (var tx = _env.NewTransaction(TransactionFlags.Read))
-			{
-			    var readResult = tx.State.FreeSpaceRoot.Read(tx, _freePagesCount);
-			    if (readResult == null)
-			        return 0;
-                return readResult.Reader.ReadInt64();
-			}
 		}
 
 		public List<long> AllPages(Transaction tx)

--- a/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
+++ b/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
@@ -5,7 +5,6 @@ namespace Voron.Impl.FreeSpace
     public interface IFreeSpaceHandling
     {
         long? TryAllocateFromFreeSpace(Transaction tx, int num);
-        long GetFreePageCount();
         List<long> AllPages(Transaction tx);
         void FreePage(Transaction tx, long pageNumber);
     }

--- a/Voron/Impl/FreeSpace/NoFreeSpaceHandling.cs
+++ b/Voron/Impl/FreeSpace/NoFreeSpaceHandling.cs
@@ -9,11 +9,6 @@ namespace Voron.Impl.FreeSpace
             return null;
         }
 
-        public long GetFreePageCount()
-        {
-            return 0;
-        }
-
         public List<long> AllPages(Transaction tx)
         {
             return new List<long>();

--- a/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -49,10 +49,10 @@ namespace Voron.Impl.FreeSpace
 
         public StreamBitArray(ValueReader reader)
         {
-            SetCount = reader.ReadInt32();
+            SetCount = reader.ReadLittleEndianInt32();
             for (var i = 0; i < _inner.Length; i++)
             {
-                _inner[i] = reader.ReadInt32();
+                _inner[i] = reader.ReadLittleEndianInt32();
             }
         }
 

--- a/Voron/Impl/Journal/JournalReader.cs
+++ b/Voron/Impl/Journal/JournalReader.cs
@@ -2,218 +2,179 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using Voron.Impl.Extensions;
 using Voron.Impl.Paging;
 using Voron.Util;
 
 namespace Voron.Impl.Journal
 {
-	public unsafe class JournalReader
-	{
-		private readonly IVirtualPager _pager;
-		private readonly IVirtualPager _recoveryPager;
+    public unsafe class JournalReader
+    {
+        private readonly IVirtualPager _pager;
+        private readonly IVirtualPager _recoveryPager;
 
-		private readonly long _lastSyncedTransactionId;
-		private long _readingPage;
+        private readonly long _lastSyncedTransactionId;
+        private long _readingPage;
 
-		private uint _previousTransactionCrc;
+        private readonly Dictionary<long, JournalFile.PagePosition> _transactionPageTranslation = new Dictionary<long, JournalFile.PagePosition>();
+        private int _recoveryPage;
 
-		private readonly Dictionary<long, JournalFile.PagePosition> _transactionPageTranslation = new Dictionary<long, JournalFile.PagePosition>();
-		private int _recoveryPage;
+        public bool RequireHeaderUpdate { get; private set; }
 
-		public bool RequireHeaderUpdate { get; private set; }
+        public long NextWritePage
+        {
+            get { return _readingPage; }
+        }
 
-		public long NextWritePage
-		{
-			get { return _readingPage; }
-		}
+        public JournalReader(IVirtualPager pager, IVirtualPager recoveryPager, long lastSyncedTransactionId, TransactionHeader* previous)
+        {
+            RequireHeaderUpdate = false;
+            _pager = pager;
+            _recoveryPager = recoveryPager;
+            _lastSyncedTransactionId = lastSyncedTransactionId;
+            _readingPage = 0;
+            _recoveryPage = 0;
+            LastTransactionHeader = previous;
+        }
 
-		public JournalReader(IVirtualPager pager, IVirtualPager recoveryPager, long lastSyncedTransactionId, TransactionHeader* previous)
-		{
-			if (pager == null) throw new ArgumentNullException("pager");
+        public TransactionHeader* LastTransactionHeader { get; private set; }
 
-			RequireHeaderUpdate = false;
-			_pager = pager;
-			_recoveryPager = recoveryPager;
-			_lastSyncedTransactionId = lastSyncedTransactionId;
-			_readingPage = 0;
-			_recoveryPage = 0;
-			LastTransactionHeader = previous;
-			_previousTransactionCrc = 0;
-		}
+        public bool ReadOneTransaction(StorageEnvironmentOptions options,bool checkCrc = true)
+        {
+            if (_readingPage >= _pager.NumberOfAllocatedPages)
+                return false;
 
-		public TransactionHeader* LastTransactionHeader { get; private set; }
+            TransactionHeader* current;
+            if (!TryReadAndValidateHeader(options, out current))
+                return false;
 
-		protected bool ReadOneTransactionForShipping(StorageEnvironmentOptions options, out TransactionToShip transactionToShipRecord)
-		{
-			transactionToShipRecord = null;
-			if (_readingPage >= _pager.NumberOfAllocatedPages)
-				return false;
+            var compressedPages = (current->CompressedSize / AbstractPager.PageSize) + (current->CompressedSize % AbstractPager.PageSize == 0 ? 0 : 1);
 
-			TransactionHeader* current;
-			if (!TryReadAndValidateHeader(options, out current))
-				return false;
+            if (current->TransactionId <= _lastSyncedTransactionId)
+            {
+	            LastTransactionHeader = current;
+                _readingPage += compressedPages;
+                return true; // skipping
+            }
 
-			var compressedPageCount = (current->CompressedSize / AbstractPager.PageSize) + (current->CompressedSize % AbstractPager.PageSize == 0 ? 0 : 1);
-			if (current->TransactionId <= _lastSyncedTransactionId)
-			{
-				LastTransactionHeader = current;
-				_readingPage += compressedPageCount;
-				return true; // skipping
-			}
+	        if (checkCrc)
+	        {
+		        uint crc = Crc.Value(_pager.AcquirePagePointer(_readingPage), 0, compressedPages * AbstractPager.PageSize);
 
-			if (!ValidatePagesCrc(options, compressedPageCount, current))
-				return false;
+				if (crc != current->Crc)
+				{
+					RequireHeaderUpdate = true;
+					options.InvokeRecoveryError(this, "Invalid CRC signature for transaction " + current->TransactionId, null);
 
-			var compressedPagesRaw = new byte[compressedPageCount * AbstractPager.PageSize];
-			fixed (byte* compressedDataPtr = compressedPagesRaw)
-				NativeMethods.memcpy(compressedDataPtr, _pager.AcquirePagePointer(_readingPage), compressedPageCount * AbstractPager.PageSize);
+					return false;
+				}
+	        }
 
-			transactionToShipRecord = new TransactionToShip(*current)
-			{
-				CompressedData = new MemoryStream(compressedPagesRaw), //no need to compress the pages --> after being written to Journal they are already compressed
-				PreviousTransactionCrc = _previousTransactionCrc
-			};
+            _recoveryPager.EnsureContinuous(null, _recoveryPage, (current->PageCount + current->OverflowPageCount) + 1);
+            var dataPage = _recoveryPager.AcquirePagePointer(_recoveryPage);
 
-			_previousTransactionCrc = current->Crc;
+            NativeMethods.memset(dataPage, 0, (current->PageCount + current->OverflowPageCount) * AbstractPager.PageSize);
+            try
+            {
+                LZ4.Decode64(_pager.AcquirePagePointer(_readingPage), current->CompressedSize, dataPage, current->UncompressedSize, true);
+            }
+            catch (Exception e)
+            {
+                options.InvokeRecoveryError(this, "Could not de-compress, invalid data", e);
+                RequireHeaderUpdate = true;
 
-			_readingPage += compressedPageCount;
-			return true;
-		}
+                return false;   
+            }
 
-		public IEnumerable<TransactionToShip> ReadJournalForShipping(StorageEnvironmentOptions options)
-		{
-			TransactionToShip transactionToShip;
-			while (ReadOneTransactionForShipping(options, out transactionToShip))
-				yield return transactionToShip;
-		}
+            var tempTransactionPageTranslaction = new Dictionary<long, JournalFile.PagePosition>();
 
-		public bool ReadOneTransaction(StorageEnvironmentOptions options, bool checkCrc = true)
-		{
-			if (_readingPage >= _pager.NumberOfAllocatedPages)
-				return false;
+            for (var i = 0; i < current->PageCount; i++)
+            {
+                Debug.Assert(_pager.Disposed == false);
+                Debug.Assert(_recoveryPager.Disposed == false);
 
-			TransactionHeader* current;
-			if (!TryReadAndValidateHeader(options, out current))
-				return false;
+                var page = _recoveryPager.Read(_recoveryPage);
 
-			var compressedPages = (current->CompressedSize / AbstractPager.PageSize) + (current->CompressedSize % AbstractPager.PageSize == 0 ? 0 : 1);
+				 tempTransactionPageTranslaction[page.PageNumber] = new JournalFile.PagePosition
+                {
+                    JournalPos = _recoveryPage,
+                    TransactionId = current->TransactionId
+                };
 
-			if (current->TransactionId <= _lastSyncedTransactionId)
-			{
-				LastTransactionHeader = current;
-				_readingPage += compressedPages;
-				return true; // skipping
-			}
+                if (page.IsOverflow)
+                {
+                    var numOfPages = _recoveryPager.GetNumberOfOverflowPages(page.OverflowSize);
+                    _recoveryPage += numOfPages;
+                }
+                else
+                {
+                    _recoveryPage++;
+                }
+            }
 
-			if (checkCrc && !ValidatePagesCrc(options, compressedPages, current))
-				return false;
+            _readingPage += compressedPages;
 
-			var totalPageCount = current->PageCount + current->OverflowPageCount;
+            LastTransactionHeader = current;
+			
+            foreach (var pagePosition in tempTransactionPageTranslaction)
+            {
+                _transactionPageTranslation[pagePosition.Key] = pagePosition.Value;
+            }
 
-			_recoveryPager.EnsureContinuous(null, _recoveryPage, totalPageCount + 1);
-			var dataPage = _recoveryPager.AcquirePagePointer(_recoveryPage);
+            return true;
+        }
 
-			NativeMethods.memset(dataPage, 0, totalPageCount * AbstractPager.PageSize);
-			try
-			{
-				LZ4.Decode64(_pager.AcquirePagePointer(_readingPage), current->CompressedSize, dataPage, current->UncompressedSize, true);
-			}
-			catch (Exception e)
-			{
-				options.InvokeRecoveryError(this, "Could not de-compress, invalid data", e);
-				RequireHeaderUpdate = true;
+        public void RecoverAndValidate(StorageEnvironmentOptions options)
+        {
+            while (ReadOneTransaction(options))
+            {
+            }
+        }
 
-				return false;
-			}
+        public Dictionary<long, JournalFile.PagePosition> TransactionPageTranslation
+        {
+            get { return _transactionPageTranslation; }
+        }
 
-			var tempTransactionPageTranslaction = (*current).GetTransactionToPageTranslation(_recoveryPager, ref _recoveryPage);
+        private bool TryReadAndValidateHeader(StorageEnvironmentOptions options,out TransactionHeader* current)
+        {
+            current = (TransactionHeader*)_pager.Read(_readingPage).Base;
 
-			_readingPage += compressedPages;
+            if (current->HeaderMarker != Constants.TransactionHeaderMarker)
+            {
+                // not a transaction page, 
 
-			LastTransactionHeader = current;
-
-			foreach (var pagePosition in tempTransactionPageTranslaction)
-			{
-				_transactionPageTranslation[pagePosition.Key] = pagePosition.Value;
-			}
-
-			return true;
-		}
-
-		
-
-		private bool ValidatePagesCrc(StorageEnvironmentOptions options, int compressedPages, TransactionHeader* current)
-		{
-			uint crc = Crc.Value(_pager.AcquirePagePointer(_readingPage), 0, compressedPages * AbstractPager.PageSize);
-
-			if (crc != current->Crc)
-			{
-				RequireHeaderUpdate = true;
-				options.InvokeRecoveryError(this, "Invalid CRC signature for transaction " + current->TransactionId, null);
-
-				return false;
-			}
-			return true;
-		}
-
-		public void RecoverAndValidate(StorageEnvironmentOptions options)
-		{
-			if (_recoveryPager == null) throw new InvalidOperationException("recoveryPager should not be null");
-
-			while (ReadOneTransaction(options))
-			{
-			}
-		}
-
-		
-
-		public Dictionary<long, JournalFile.PagePosition> TransactionPageTranslation
-		{
-			get { return _transactionPageTranslation; }
-		}
-
-		private bool TryReadAndValidateHeader(StorageEnvironmentOptions options, out TransactionHeader* current)
-		{
-			current = (TransactionHeader*)_pager.Read(_readingPage).Base;
-
-			if (current->HeaderMarker != Constants.TransactionHeaderMarker)
-			{
-				// not a transaction page, 
-
-				// if the header marker is zero, we are probably in the area at the end of the log file, and have no additional log records
-				// to read from it. This can happen if the next transaction was too big to fit in the current log file. We stop reading
-				// this log file and move to the next one. 
+                // if the header marker is zero, we are probably in the area at the end of the log file, and have no additional log records
+                // to read from it. This can happen if the next transaction was too big to fit in the current log file. We stop reading
+                // this log file and move to the next one. 
 
 				RequireHeaderUpdate = current->HeaderMarker != 0;
-				if (RequireHeaderUpdate)
-				{
-					options.InvokeRecoveryError(this,
-						"Transaction " + current->TransactionId +
-						" header marker was set to garbage value, file is probably corrupted", null);
-				}
+                if (RequireHeaderUpdate)
+                {
+                    options.InvokeRecoveryError(this,
+                        "Transaction " + current->TransactionId +
+                        " header marker was set to garbage value, file is probably corrupted", null);
+                }
 
-				return false;
-			}
+                return false;
+            }
 
-			ValidateHeader(current, LastTransactionHeader);
+            ValidateHeader(current, LastTransactionHeader);
 
-			if (current->TxMarker.HasFlag(TransactionMarker.Commit) == false)
-			{
-				// uncommitted transaction, probably
-				RequireHeaderUpdate = true;
-				options.InvokeRecoveryError(this,
-						"Transaction " + current->TransactionId +
-						" was not committed", null);
-				return false;
-			}
+            if (current->TxMarker.HasFlag(TransactionMarker.Commit) == false)
+            {
+                // uncommitted transaction, probably
+                RequireHeaderUpdate = true;
+                options.InvokeRecoveryError(this,
+                        "Transaction " + current->TransactionId +
+                        " was not committed", null);
+                return false;
+            }
 
-			_readingPage++;
-			return true;
-		}
+            _readingPage++;
+            return true;
+        }
 
-		private void ValidateHeader(TransactionHeader* current, TransactionHeader* previous)
+        private void ValidateHeader(TransactionHeader* current, TransactionHeader* previous)
 		{
 			if (current->TransactionId < 0)
 				throw new InvalidDataException("Transaction id cannot be less than 0 (Tx: " + current->TransactionId + " )");
@@ -225,8 +186,7 @@ namespace Voron.Impl.Journal
 			{
 				if (current->CompressedSize <= 0)
 					throw new InvalidDataException("Compression error in transaction.");
-			}
-			else
+			} else
 				throw new InvalidDataException("Uncompressed transactions are not supported.");
 
 			if (previous == null)
@@ -243,5 +203,5 @@ namespace Voron.Impl.Journal
 		{
 			return _pager.ToString();
 		}
-	}
+    }
 }

--- a/Voron/Impl/Journal/Win32JournalWriter.cs
+++ b/Voron/Impl/Journal/Win32JournalWriter.cs
@@ -72,7 +72,11 @@ namespace Voron.Impl.Journal
 			}
 			_segments[pages.Length].Buffer = null; // null terminating
 
-			WriteFileGather(_handle, _segments, (uint) pages.Length*4096, IntPtr.Zero, _nativeOverlapped);
+			var operationCompleted = WriteFileGather(_handle, _segments, (uint) pages.Length*4096, IntPtr.Zero, _nativeOverlapped);
+
+			if (operationCompleted) 
+				return;
+
 			switch (Marshal.GetLastWin32Error())
 			{
 				case ErrorSuccess:

--- a/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -5,14 +5,11 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Voron.Exceptions;
 using Voron.Impl.FileHeaders;
 using Voron.Impl.Paging;
@@ -21,6 +18,8 @@ using Voron.Util;
 
 namespace Voron.Impl.Journal
 {
+	using System.IO;
+
 	public unsafe class WriteAheadJournal : IDisposable
 	{
 		private readonly StorageEnvironment _env;
@@ -32,17 +31,14 @@ namespace Voron.Impl.Journal
 		private long _journalIndex = -1;
 		private readonly LZ4 _lz4 = new LZ4();
 		private readonly JournalApplicator _journalApplicator;
-		private readonly JournalShipper _journalShipper;
-		private readonly ReaderWriterLockSlim _journalSyncObj;
 		private readonly ModifyHeaderAction _updateLogInfo;
-		
+
 		private ImmutableAppendOnlyList<JournalFile> _files = ImmutableAppendOnlyList<JournalFile>.Empty;
 		internal JournalFile CurrentFile;
 
 		private readonly HeaderAccessor _headerAccessor;
-		private readonly IVirtualPager _compressionPager;
 
-		public event Action<TransactionToShip> OnTransactionCommit;
+		private IVirtualPager _compressionPager;
 
 		public WriteAheadJournal(StorageEnvironment env)
 		{
@@ -59,16 +55,12 @@ namespace Voron.Impl.Journal
 			};
 
 			_compressionPager = _env.Options.CreateScratchPager("compression.buffers");
-			_journalSyncObj = new ReaderWriterLockSlim();
-			_journalApplicator = new JournalApplicator(this, _journalSyncObj);
-			_journalShipper = new JournalShipper(this, _journalSyncObj);
+			_journalApplicator = new JournalApplicator(this);
 		}
 
 		public ImmutableAppendOnlyList<JournalFile> Files { get { return _files; } }
 
 		public JournalApplicator Applicator { get { return _journalApplicator; } }
-
-		public JournalShipper Shipper { get { return _journalShipper; } }
 
 		private JournalFile NextFile(int numberOfPages = 1)
 		{
@@ -124,6 +116,7 @@ namespace Voron.Impl.Journal
 					if (_env.Options.TryDeleteJournal(unusedfiles) == false)
 						break;
 				}
+
 			}
 
 			var lastSyncedTransactionId = logInfo.LastSyncedTransactionId;
@@ -154,7 +147,7 @@ namespace Voron.Impl.Journal
 					{
 						if (pagesToWrite.Count > 0)
 							ApplyPagesToDataFileFromJournal(pagesToWrite);
-						
+
 						*txHeader = *lastReadHeaderPtr;
 						lastSyncedTxId = txHeader->TransactionId;
 						lastSyncedJournal = journalNumber;
@@ -257,10 +250,12 @@ namespace Voron.Impl.Journal
 			if (journalSize >= _env.Options.MaxLogFileSize) // can't set for more than the max log file size
 				return;
 
-			_currentJournalFileSize = journalSize;
+			// this set the size of the _next_ journal file size
+			_currentJournalFileSize = Math.Min(journalSize, _env.Options.MaxLogFileSize);
 		}
 
-		public Page ReadPage(Transaction tx, long pageNumber)
+
+		public Page ReadPage(Transaction tx, long pageNumber, PagerState scratchPagerState)
 		{
 			// read transactions have to read from journal snapshots
 			if (tx.Flags == TransactionFlags.Read)
@@ -271,7 +266,7 @@ namespace Voron.Impl.Journal
 					JournalFile.PagePosition value;
 					if (tx.JournalSnapshots[i].PageTranslationTable.TryGetValue(tx, pageNumber, out value))
 					{
-						var page = _env.ScratchBufferPool.ReadPage(value.ScratchPos);
+						var page = _env.ScratchBufferPool.ReadPage(value.ScratchPos, scratchPagerState);
 
 						Debug.Assert(page.PageNumber == pageNumber);
 
@@ -289,7 +284,7 @@ namespace Voron.Impl.Journal
 				JournalFile.PagePosition value;
 				if (files[i].PageTranslationTable.TryGetValue(tx, pageNumber, out value))
 				{
-					var page = _env.ScratchBufferPool.ReadPage(value.ScratchPos);
+					var page = _env.ScratchBufferPool.ReadPage(value.ScratchPos, scratchPagerState);
 
 					Debug.Assert(page.PageNumber == pageNumber);
 
@@ -356,89 +351,11 @@ namespace Voron.Impl.Journal
 			CurrentFile = null;
 		}
 
-		public class JournalSyncEventArgs : EventArgs
-		{
-			public long OldestTransactionId { get; private set; }
-
-			public JournalSyncEventArgs(long oldestTransactionId)
-			{
-				OldestTransactionId = oldestTransactionId;
-			}
-		}
-
-		public class JournalShipper
-		{
-			private readonly ReaderWriterLockSlim _shippingSemaphore;
-			private readonly WriteAheadJournal _waj;
-
-			public JournalShipper(WriteAheadJournal waj, ReaderWriterLockSlim shippingSemaphore = null)
-			{
-				_waj = waj;
-				_shippingSemaphore = shippingSemaphore ?? new ReaderWriterLockSlim();
-			}
-
-			public IEnumerable<TransactionToShip> ReadJournalForShippings(long lastTransactionId)
-			{
-				bool locked = false;
-				if (_shippingSemaphore.IsReadLockHeld == false)
-				{
-					if (_shippingSemaphore.TryEnterReadLock(Debugger.IsAttached ? TimeSpan.FromMinutes(30) : TimeSpan.FromSeconds(30)) == false)
-						throw new TimeoutException("Could not acquire the read lock in 30 seconds");
-					locked = true;
-				}
-
-				try
-				{
-					var logInfo = _waj._headerAccessor.Get(ptr => ptr->Journal);
-					var transactionsToShip = new List<TransactionToShip>();
-
-					for (int journalNumber = 0; journalNumber < logInfo.JournalFilesCount; journalNumber++)
-					{
-						var journalReader = new JournalReader(_waj._env.Options.OpenJournalPager(journalNumber), null, lastTransactionId, null);
-						var journalLogs = journalReader.ReadJournalForShipping(_waj._env.Options).ToList();
-
-						if (journalLogs.Count > 0)
-							transactionsToShip.AddRange(journalLogs);
-					}
-
-					return transactionsToShip;
-				}
-				finally
-				{
-					if(locked)
-						_shippingSemaphore.ExitReadLock();
-				}
-			}
-
-			public void ApplyShippedLogs(IEnumerable<TransactionToShip> shippedTransactions)
-			{
-				if(shippedTransactions == null)
-					throw new ArgumentNullException();
-				shippedTransactions = shippedTransactions.OrderBy(x => x.Header.TransactionId).ToList();
-
-				if (shippedTransactions.Any() == false)
-					return;
-				
-				using (var tempPager = _waj._env.Options.CreateScratchPager(StorageEnvironmentOptions.TempBufferName()))
-				{
-					tempPager.DeleteOnClose = true;
-					var shippedTransactionsReader = new ShippedTransactionsReader(tempPager);
-					shippedTransactionsReader.ReadTransactions(shippedTransactions);
-
-					using (var tx = _waj._env.NewTransaction(TransactionFlags.ReadWrite))
-					{
-						tx.WriteDirect(shippedTransactionsReader.RawPageData);						
-						tx.Commit();
-					}
-				}
-			}
-		}
-
 		public class JournalApplicator : IDisposable
 		{
-			private const long DelayedDataFileSynchronizationBytesLimit = 2L*1024*1024*1024;
-			private readonly TimeSpan DelayedDataFileSynchronizationTimeLimit = TimeSpan.FromMinutes(1);
-            private readonly ReaderWriterLockSlim _flushingSemaphore;
+			private const long DelayedDataFileSynchronizationBytesLimit = 2L * 1024 * 1024 * 1024;
+			private readonly TimeSpan _delayedDataFileSynchronizationTimeLimit = TimeSpan.FromMinutes(1);
+			private readonly ReaderWriterLockSlim _flushingSemaphore = new ReaderWriterLockSlim();
 			private readonly Dictionary<long, JournalFile> _journalsToDelete = new Dictionary<long, JournalFile>();
 			private readonly WriteAheadJournal _waj;
 			private long _lastSyncedTransactionId;
@@ -447,20 +364,12 @@ namespace Voron.Impl.Journal
 			private DateTime _lastDataFileSyncTime;
 			private JournalFile _lastFlushedJournal;
 
-			public event EventHandler<JournalSyncEventArgs> ApplyLogsToDataFileFinished;
-
-			public JournalApplicator(WriteAheadJournal waj, ReaderWriterLockSlim flushingSemaphore = null)
+			public JournalApplicator(WriteAheadJournal waj)
 			{
 				_waj = waj;
-				_flushingSemaphore = flushingSemaphore ?? new ReaderWriterLockSlim();
 			}
 
-			public long LastSyncedTransactionId
-			{
-				get { return _lastSyncedTransactionId; }
-			}
-
-			public void ApplyLogsToDataFile(long oldestActiveTransaction, Transaction transaction = null)
+			public void ApplyLogsToDataFile(long oldestActiveTransaction, CancellationToken token, Transaction transaction = null)
 			{
 				bool locked = false;
 				if (_flushingSemaphore.IsWriteLockHeld == false)
@@ -472,18 +381,74 @@ namespace Voron.Impl.Journal
 
 				try
 				{
+					if (token.IsCancellationRequested)
+						return;
+
 					var alreadyInWriteTx = transaction != null && transaction.Flags == TransactionFlags.ReadWrite;
 
-					var journalSnapshots = _waj.Files.Select(x => x.GetSnapshot())
-										   .OrderBy(x => x.Number)
-										   .ToList();
-
-					if (journalSnapshots.Count == 0)
+					var jrnls = _waj._files.Select(x => x.GetSnapshot()).OrderBy(x => x.Number).ToList();
+					if (jrnls.Count == 0)
 						return; // nothing to do
 
-					Debug.Assert(journalSnapshots.First().Number >= _lastSyncedJournal);
+					Debug.Assert(jrnls.First().Number >= _lastSyncedJournal);
 
-					var pagesToWrite = GetPagesFromJournals(oldestActiveTransaction, journalSnapshots);
+					var pagesToWrite = new Dictionary<long, JournalFile.PagePosition>();
+
+					long lastProcessedJournal = -1;
+					long previousJournalMaxTransactionId = -1;
+
+					long lastFlushedTransactionId = -1;
+
+					foreach (var journalFile in jrnls.Where(x => x.Number >= _lastSyncedJournal))
+					{
+						var currentJournalMaxTransactionId = -1L;
+
+						foreach (var pagePosition in journalFile.PageTranslationTable.IterateLatestAsOf(journalFile.LastTransaction))
+						{
+							if (oldestActiveTransaction != 0 &&
+								pagePosition.Value.TransactionId >= oldestActiveTransaction)
+							{
+								// we cannot write this yet, there is a read transaction that might be looking at this
+								// however, we _aren't_ going to be writing this to the data file, since that would be a 
+								// waste, we would just overwrite that value in the next flush anyway
+								JournalFile.PagePosition existingPagePosition;
+								if (pagesToWrite.TryGetValue(pagePosition.Key, out existingPagePosition) &&
+									pagePosition.Value.JournalNumber == existingPagePosition.JournalNumber)
+								{
+									// remove the page only when it comes from the same journal
+									// otherwise we can damage the journal's page translation table (PTT)
+									// because the existing overwrite in a next journal can be filtered out
+									// so we wouldn't write any page to the data file
+									pagesToWrite.Remove(pagePosition.Key);
+								}
+
+								continue;
+							}
+
+							if (journalFile.Number == _lastSyncedJournal && pagePosition.Value.TransactionId <= _lastSyncedTransactionId)
+								continue;
+
+							currentJournalMaxTransactionId = Math.Max(currentJournalMaxTransactionId, pagePosition.Value.TransactionId);
+
+							if (currentJournalMaxTransactionId < previousJournalMaxTransactionId)
+								throw new InvalidOperationException(
+									"Journal applicator read beyond the oldest active transaction in the next journal file. " +
+									"This should never happen. Current journal max tx id: " + currentJournalMaxTransactionId +
+									", previous journal max ix id: " + previousJournalMaxTransactionId +
+									", oldest active transaction: " + oldestActiveTransaction);
+
+
+							lastProcessedJournal = journalFile.Number;
+							pagesToWrite[pagePosition.Key] = pagePosition.Value;
+
+							lastFlushedTransactionId = currentJournalMaxTransactionId;
+						}
+
+						if (currentJournalMaxTransactionId == -1L)
+							continue;
+
+						previousJournalMaxTransactionId = currentJournalMaxTransactionId;
+					}
 
 					if (pagesToWrite.Count == 0)
 						return;
@@ -498,32 +463,53 @@ namespace Voron.Impl.Journal
 						return;
 					}
 
-					var unusedJournals = GetAlreadyHandledJournalFiles(journalSnapshots);
+					var unusedJournals = GetUnusedJournalFiles(jrnls, lastProcessedJournal, lastFlushedTransactionId);
+
+					foreach (var unused in unusedJournals.Where(unused => !_journalsToDelete.ContainsKey(unused.Number)))
+					{
+						_journalsToDelete.Add(unused.Number, unused);
+					}
 
 					using (var txw = alreadyInWriteTx ? null : _waj._env.NewTransaction(TransactionFlags.ReadWrite))
 					{
-						_lastFlushedJournal = _waj.Files.First(x => x.Number == _lastSyncedJournal);
+						_lastSyncedJournal = lastProcessedJournal;
+						_lastSyncedTransactionId = lastFlushedTransactionId;
 
-						RemoveUnusedJournalsIfNeeded(unusedJournals);
+						_lastFlushedJournal = _waj._files.First(x => x.Number == _lastSyncedJournal);
+
+						if (unusedJournals.Count > 0)
+						{
+							var lastUnusedJournalNumber = unusedJournals.Last().Number;
+							_waj._files = _waj._files.RemoveWhile(x => x.Number <= lastUnusedJournalNumber, new List<JournalFile>());
+						}
 
 						if (_waj._files.Count == 0)
 							_waj.CurrentFile = null;
 
 						FreeScratchPages(unusedJournals, txw);
 
-						var hasSynced = false;
 						if (_totalWrittenButUnsyncedBytes > DelayedDataFileSynchronizationBytesLimit ||
-							DateTime.Now - _lastDataFileSyncTime > DelayedDataFileSynchronizationTimeLimit)
+							DateTime.Now - _lastDataFileSyncTime > _delayedDataFileSynchronizationTimeLimit)
 						{
-							SyncDataFileWrites(oldestActiveTransaction);
-							hasSynced = true;
+							_waj._dataPager.Sync();
+
+							UpdateFileHeaderAfterDataFileSync(_lastFlushedJournal, oldestActiveTransaction);
+
+							foreach (var toDelete in _journalsToDelete.Values)
+							{
+								if (_waj._env.Options.IncrementalBackupEnabled == false)
+									toDelete.DeleteOnClose = true;
+
+								toDelete.Release();
+							}
+
+							_journalsToDelete.Clear();
+							_totalWrittenButUnsyncedBytes = 0;
+							_lastDataFileSyncTime = DateTime.Now;
 						}
 
 						if (txw != null)
 							txw.Commit();
-
-						if (hasSynced)
-							OnApplyLogsToDataFileFinished(_lastSyncedTransactionId);
 					}
 				}
 				finally
@@ -533,143 +519,7 @@ namespace Voron.Impl.Journal
 				}
 			}
 
-			private void SyncDataFileWrites(long oldestActiveTransaction)
-			{
-				_waj._dataPager.Sync();
-
-				UpdateFileHeaderAfterDataFileSync(_lastFlushedJournal, oldestActiveTransaction);
-
-				foreach (var toDelete in _journalsToDelete.Values)
-				{
-					if (_waj._env.Options.IncrementalBackupEnabled == false)
-						toDelete.DeleteOnClose = true;
-
-					toDelete.Release();
-				}
-
-				_journalsToDelete.Clear();
-				_totalWrittenButUnsyncedBytes = 0;
-				_lastDataFileSyncTime = DateTime.Now;
-			}
-
-			[MethodImpl(MethodImplOptions.AggressiveInlining)]
-			private void RemoveUnusedJournalsIfNeeded(IReadOnlyCollection<JournalFile> unusedJournals)
-			{
-				if (unusedJournals.Any())
-					_waj._files = _waj._files.RemoveWhile(x => x.Number <= unusedJournals.Last().Number, new List<JournalFile>());
-			}
-
-
-			protected IReadOnlyList<JournalFile> GetAlreadyHandledJournalFiles(IEnumerable<JournalSnapshot> journalSnapshots)
-			{
-				var unusedJournalFiles = new List<JournalFile>();
-				foreach (var j in journalSnapshots)
-				{
-					if (j.Number > _lastSyncedJournal) // after the last log we handled, nothing to do here
-						continue;
-					if (j.Number == _lastSyncedJournal) // we are in the last log we handled
-					{
-						if (j.AvailablePages != 0 || //　if there are more pages to be used here or 
-						j.PageTranslationTable.MaxTransactionId() != _lastSyncedTransactionId) // we didn't handle the whole journal
-							continue; // do not mark it as handled
-					}
-					unusedJournalFiles.Add(_waj.Files.First(x => x.Number == j.Number));
-				}
-				return unusedJournalFiles;
-			}
-
-			protected Dictionary<long, JournalFile.PagePosition> GetPagesFromJournals(long oldestActiveTransaction, IEnumerable<JournalSnapshot> journalSnapshots)
-			{
-				var pagesToWrite = new Dictionary<long, JournalFile.PagePosition>();
-
-				long lastProcessedJournal = -1;
-				long previousJournalMaxTransactionId = -1;
-				long lastFlushedTransactionId = -1;
-
-				foreach (var journalFile in journalSnapshots.Where(x => x.Number >= _lastSyncedJournal))
-				{
-					var currentJournalMaxTransactionId = -1L;
-
-					foreach (var pagePosition in journalFile.PageTranslationTable.IterateLatestAsOf(journalFile.LastTransaction))
-					{
-						if (ShouldSkipFetchingPagePosition(oldestActiveTransaction, pagePosition, pagesToWrite))
-							continue;
-
-						var isAlreadyHandled = journalFile.Number == _lastSyncedJournal &&
-													pagePosition.Value.TransactionId <= _lastSyncedTransactionId;
-						if (isAlreadyHandled)
-							continue;
-
-						currentJournalMaxTransactionId = GetAndValidateOldestTransactionId(currentJournalMaxTransactionId,
-																						   oldestActiveTransaction,
-																						   pagePosition,
-																						   previousJournalMaxTransactionId);
-
-						lastProcessedJournal = journalFile.Number;
-						pagesToWrite[pagePosition.Key] = pagePosition.Value;
-
-						lastFlushedTransactionId = currentJournalMaxTransactionId;
-					}
-
-					if (currentJournalMaxTransactionId == -1L)
-						continue;
-
-					previousJournalMaxTransactionId = currentJournalMaxTransactionId;
-				}
-
-				_lastSyncedJournal = lastProcessedJournal;
-				_lastSyncedTransactionId = lastFlushedTransactionId;
-
-				return pagesToWrite;
-			}
-
-			private static long GetAndValidateOldestTransactionId(long currentJournalMaxTransactionId, long oldestActiveTransaction,
-				KeyValuePair<long, JournalFile.PagePosition> pagePosition, long previousJournalMaxTransactionId)
-			{
-				currentJournalMaxTransactionId = Math.Max(currentJournalMaxTransactionId, pagePosition.Value.TransactionId);
-
-				if (currentJournalMaxTransactionId < previousJournalMaxTransactionId)
-					throw new InvalidOperationException(
-						"Journal applicator read beyond the oldest active transaction in the next journal file. " +
-						"This should never happen. Current journal max tx id: " + currentJournalMaxTransactionId +
-						", previous journal max ix id: " + previousJournalMaxTransactionId +
-						", oldest active transaction: " + oldestActiveTransaction);
-				return currentJournalMaxTransactionId;
-			}
-
-			protected static bool ShouldSkipFetchingPagePosition(long oldestActiveTransaction, KeyValuePair<long, JournalFile.PagePosition> pagePosition,
-							Dictionary<long, JournalFile.PagePosition> pagesToWrite)
-			{
-				if (oldestActiveTransaction != 0 &&
-					pagePosition.Value.TransactionId >= oldestActiveTransaction)
-				{
-					// we cannot write this yet, there is a read transaction that might be looking at this
-					// however, we _aren't_ going to be writing this to the data file, since that would be a 
-					// waste, we would just overwrite that value in the next flush anyway
-					JournalFile.PagePosition existingPagePosition;
-					if (pagesToWrite.TryGetValue(pagePosition.Key, out existingPagePosition) &&
-						pagePosition.Value.JournalNumber == existingPagePosition.JournalNumber)
-					{
-						// remove the page only when it comes from the same journal
-						// otherwise we can damage the journal's page translation table (PTT)
-						// because the existing overwrite in a next journal can be filtered out
-						// so we wouldn't write any page to the data file
-						pagesToWrite.Remove(pagePosition.Key);
-					}
-
-					return true;
-				}
-				return false;
-			}
-
-			protected void OnApplyLogsToDataFileFinished(long oldestTransactionId)
-			{
-				var applyLogsToDataFileFinished = ApplyLogsToDataFileFinished;
-				if (applyLogsToDataFileFinished != null)
-					applyLogsToDataFileFinished(this, new JournalSyncEventArgs(oldestTransactionId));
-			}
-
-			public Dictionary<long, int> writtenPages = new Dictionary<long, int>(); 
+			public Dictionary<long, int> writtenPages = new Dictionary<long, int>();
 
 			private void ApplyPagesToDataFileFromScratch(Dictionary<long, JournalFile.PagePosition> pagesToWrite, Transaction transaction, bool alreadyInWriteTx)
 			{
@@ -680,8 +530,8 @@ namespace Voron.Impl.Journal
 				try
 				{
 					var sortedPages = pagesToWrite.OrderBy(x => x.Key)
-												  .Select(x => scratchBufferPool.ReadPage(x.Value.ScratchPos, scratchPagerState))
-											      .ToList();
+													.Select(x => scratchBufferPool.ReadPage(x.Value.ScratchPos, scratchPagerState))
+													.ToList();
 
 					var last = sortedPages.Last();
 
@@ -737,10 +587,29 @@ namespace Voron.Impl.Journal
 					journalFile.FreeScratchPagesOlderThan(txw, _lastSyncedTransactionId);
 				}
 
+
 				foreach (var jrnl in _waj._files.OrderBy(x => x.Number))
 				{
 					jrnl.FreeScratchPagesOlderThan(txw, _lastSyncedTransactionId);
 				}
+			}
+
+			private List<JournalFile> GetUnusedJournalFiles(IEnumerable<JournalSnapshot> jrnls, long lastProcessedJournal, long lastFlushedTransactionId)
+			{
+				var unusedJournalFiles = new List<JournalFile>();
+				foreach (var j in jrnls)
+				{
+					if (j.Number > lastProcessedJournal) // after the last log we synced, nothing to do here
+						continue;
+					if (j.Number == lastProcessedJournal) // we are in the last log we synced
+					{
+						if (j.AvailablePages != 0 || //　if there are more pages to be used here or 
+						j.PageTranslationTable.MaxTransactionId() != lastFlushedTransactionId) // we didn't synchronize whole journal
+							continue; // do not mark it as unused
+					}
+					unusedJournalFiles.Add(_waj._files.First(x => x.Number == j.Number));
+				}
+				return unusedJournalFiles;
 			}
 
 			public void UpdateFileHeaderAfterDataFileSync(JournalFile file, long oldestActiveTransaction)
@@ -760,7 +629,7 @@ namespace Voron.Impl.Journal
 						break;
 
 					lastReadTxHeader = *readTxHeader;
-					
+
 					var compressedPages = (readTxHeader->CompressedSize / AbstractPager.PageSize) + (readTxHeader->CompressedSize % AbstractPager.PageSize == 0 ? 0 : 1);
 
 					txPos += compressedPages + 1;
@@ -796,51 +665,29 @@ namespace Voron.Impl.Journal
 				}
 			}
 
-		    public IDisposable TakeFlushingLock()
-		    {
-                _flushingSemaphore.EnterWriteLock();
-                return new DisposableAction(() => _flushingSemaphore.ExitWriteLock());
-		    }
+			public IDisposable TakeFlushingLock()
+			{
+				_flushingSemaphore.EnterWriteLock();
+				return new DisposableAction(() => _flushingSemaphore.ExitWriteLock());
+			}
 		}
-
-		private uint _previousTransactionCrc;
 
 		public void WriteToJournal(Transaction tx, int pageCount)
 		{
-		    var pages = CompressPages(tx, pageCount, _compressionPager);
+			var pages = CompressPages(tx, pageCount, _compressionPager);
 
-		    if (CurrentFile == null || CurrentFile.AvailablePages < pages.Length)
-		    {
-		        CurrentFile = NextFile(pages.Length);
-		    }
-
-			var transactionHeader = *(TransactionHeader*)pages[0];
-
-			var writePage = CurrentFile.Write(tx, pages);
-			
-			var onTransactionCommit =  OnTransactionCommit;
-			if (onTransactionCommit != null)
+			if (CurrentFile == null || CurrentFile.AvailablePages < pages.Length)
 			{
-				var bufferSize = pages.Length * AbstractPager.PageSize;
-				var buffer = new byte[bufferSize];
-				
-				fixed (byte* bp = buffer)
-					CurrentFile.JournalWriter.Read(writePage, bp, bufferSize);
-				
-				var stream = new MemoryStream(buffer,AbstractPager.PageSize, (pages.Length - 1) * AbstractPager.PageSize);
-				var transactionToShip = new TransactionToShip(transactionHeader)
-				{
-					CompressedData = stream, 
-					PreviousTransactionCrc = _previousTransactionCrc
-				};
-
-				_previousTransactionCrc = transactionHeader.Crc;
-				onTransactionCommit(transactionToShip);
+				CurrentFile = NextFile(pages.Length);
+			}
+			CurrentFile.Write(tx, pages);
+			if (CurrentFile.AvailablePages == 0)
+			{
+				CurrentFile = null;
 			}
 
-		    if (CurrentFile.AvailablePages == 0)
-		        CurrentFile = null;
 		}
+
 
 		private byte*[] CompressPages(Transaction tx, int numberOfPages, IVirtualPager compressionPager)
 		{
@@ -868,19 +715,19 @@ namespace Voron.Impl.Journal
 				write += count;
 			}
 
-			var sizeAfterCompression = DoCompression(tempBuffer, compressionBuffer, sizeInBytes, outputBuffer);
+			var len = DoCompression(tempBuffer, compressionBuffer, sizeInBytes, outputBuffer);
+			var compressedPages = (len / AbstractPager.PageSize) + (len % AbstractPager.PageSize == 0 ? 0 : 1);
 
-			var compressedPages = (sizeAfterCompression / AbstractPager.PageSize) + (sizeAfterCompression % AbstractPager.PageSize == 0 ? 0 : 1);
+			var pages = new byte*[compressedPages + 1];
+
 			var txHeaderBase = tx.Environment.ScratchBufferPool.AcquirePagePointer(txPages[0].PositionInScratchBuffer);
 			var txHeader = (TransactionHeader*)txHeaderBase;
 
 			txHeader->Compressed = true;
-			txHeader->CompressedSize = sizeAfterCompression;
+			txHeader->CompressedSize = len;
 			txHeader->UncompressedSize = sizeInBytes;
 
-			var pages = new byte*[compressedPages + 1];
 			pages[0] = txHeaderBase;
-
 			for (int index = 0; index < compressedPages; index++)
 			{
 				pages[index + 1] = compressionBuffer + (index * AbstractPager.PageSize);
@@ -902,140 +749,5 @@ namespace Voron.Impl.Journal
 
 			return doCompression;
 		}
-	}
-
-	public unsafe class UnmanagedVectorMemoryStream : Stream
-	{
-		private readonly byte*[] _pages;
-		private readonly int _start;
-		private readonly int _pageSize;
-		
-		public UnmanagedVectorMemoryStream(byte*[] pages, int start, int pageSize)
-		{
-			_pages = pages;
-			_start = start;
-			_pageSize = pageSize;
-			_length = _pageSize*(_pages.Length - start);
-		}
-
-#if DEBUG
-		internal byte[] DebugReadAllData(int pageSize = 0)
-		{
-			if (pageSize == 0)
-				pageSize = _pageSize;
-
-			var buffer = new byte[pageSize*(_pages.Length - _start)];
-
-			fixed(byte* bp = buffer)
-				for (int pageIndex = _start; pageIndex < _pages.Length; pageIndex++)
-					NativeMethods.memcpy(bp + ((pageIndex - _start)*pageSize), _pages[pageIndex], pageSize);
-
-			return buffer;
-		}
-#endif
-		public override void Flush()
-		{
-			throw new NotSupportedException();
-		}
-
-		public override long Seek(long offset, SeekOrigin origin)
-		{
-			switch (origin)
-			{
-					case SeekOrigin.Current:
-						if (Position + offset > Length)
-							throw new ArgumentOutOfRangeException("offset");
-						Position += offset;
-						break;
-					case SeekOrigin.Begin:
-						if(offset > Length || offset < 0)
-							throw new ArgumentOutOfRangeException("offset");
-						Position = offset;
-						break;
-					case SeekOrigin.End:
-						if(offset > Length)
-							throw new ArgumentOutOfRangeException("offset");
-						Position = Length - offset;
-						break;
-			}
-
-			return Position;
-		}
-
-		public override void SetLength(long value)
-		{
-			throw new NotSupportedException();
-		}
-
-		public override int Read(byte[] buffer, int offset, int count)
-		{
-			fixed (byte* pb = buffer)			
-			{				
-				count = Math.Min(count, (int) (Length - Position));
-				if (count == 0)
-					return 0;
-				int read = 0;
-
-				var pageSpan = count / _pageSize;
-				if (count % _pageSize > 0) //consider in page span also partial pages
-					pageSpan++;
-
-				var startPage = (Position / _pageSize) + _start;
-				var positionInStartPage = (int)(Position % _pageSize);
-				var endPage = startPage + pageSpan - 1;
-
-				Debug.Assert(endPage >= startPage);
-
-				int firstPageCount = _pageSize - positionInStartPage;
-				NativeMethods.memcpy(pb + offset, _pages[startPage] + positionInStartPage, firstPageCount);
-				read += firstPageCount;
-				count -= firstPageCount;
-
-				for (var pageIndex = startPage + 1; pageIndex < endPage; pageIndex++)
-				{
-					NativeMethods.memcpy(pb + offset + read, _pages[pageIndex], _pageSize);
-					read += _pageSize;
-					count -= _pageSize;
-				}
-
-				if (count > 0)
-				{
-					NativeMethods.memcpy(pb + offset + read, _pages[endPage], count);
-					read += count;
-				}
-
-				Position += read;
-				return read;
-			}
-		}
-
-		public override void Write(byte[] buffer, int offset, int count)
-		{
-			throw new NotSupportedException();
-		}
-
-		public override bool CanRead
-		{
-			get { return true; }
-		}
-
-		public override bool CanSeek
-		{
-			get { return true; }
-		}
-
-		public override bool CanWrite
-		{
-			get { return false; }
-		}
-
-
-		private readonly long _length;
-		public override long Length
-		{
-			get { return _length; }
-		}
-
-		public override long Position { get; set; }
 	}
 }

--- a/Voron/Impl/Paging/AbstractPager.cs
+++ b/Voron/Impl/Paging/AbstractPager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Voron.Trees;
@@ -11,7 +12,6 @@ namespace Voron.Impl.Paging
     public unsafe abstract class AbstractPager : IVirtualPager
     {
         protected int MinIncreaseSize { get { return 16 * PageSize; } }
-
         private long _increaseSize;
         private DateTime _lastIncrease;
 
@@ -19,20 +19,19 @@ namespace Voron.Impl.Paging
         {
 	        get
 	        {
-				Debug.Assert(Disposed == false);
-
-				return _pagerState;
+		        ThrowObjectDisposedIfNeeded();
+		        return _pagerState;
 	        }
-            set
+	        set
             {
-				Debug.Assert(Disposed == false);
+				ThrowObjectDisposedIfNeeded();
 				
                 _source = GetSourceName();
                 _pagerState = value;
             }
         }
 
-        private string _source;
+	    private string _source;
         protected AbstractPager()
         {
             _increaseSize = MinIncreaseSize;
@@ -58,7 +57,7 @@ namespace Voron.Impl.Paging
 
         public Page Read(long pageNumber, PagerState pagerState = null)
         {
-			Debug.Assert(Disposed == false);
+			ThrowObjectDisposedIfNeeded();
 			
             if (pageNumber + 1 > NumberOfAllocatedPages)
             {
@@ -66,14 +65,14 @@ namespace Voron.Impl.Paging
                                                     " because number of allocated pages is " + NumberOfAllocatedPages);
             }
 
-            return new Page(AcquirePagePointer(pageNumber, pagerState), _source);
+            return new Page(AcquirePagePointer(pageNumber, pagerState), _source, PageSize);
         }
 
         protected abstract string GetSourceName();
 
         public virtual Page GetWritable(long pageNumber)
         {
-			Debug.Assert(Disposed == false);
+			ThrowObjectDisposedIfNeeded();
 			
             if (pageNumber + 1 > NumberOfAllocatedPages)
             {
@@ -81,7 +80,7 @@ namespace Voron.Impl.Paging
                                                     " because number of allocated pages is " + NumberOfAllocatedPages);
             }
 
-            return new Page(AcquirePagePointer(pageNumber), _source);
+            return new Page(AcquirePagePointer(pageNumber), _source, PageSize);
         }
 
         public abstract byte* AcquirePagePointer(long pageNumber, PagerState pagerState = null);
@@ -90,7 +89,7 @@ namespace Voron.Impl.Paging
 
         public virtual PagerState TransactionBegan()
         {
-			Debug.Assert(Disposed == false);
+			ThrowObjectDisposedIfNeeded();
 
             var state = PagerState;
             state.AddRef();
@@ -99,14 +98,14 @@ namespace Voron.Impl.Paging
 
         public bool WillRequireExtension(long requestedPageNumber, int numberOfPages)
         {
-			Debug.Assert(Disposed == false);
+			ThrowObjectDisposedIfNeeded();
 			
             return requestedPageNumber + numberOfPages > NumberOfAllocatedPages;
         }
 
         public void EnsureContinuous(Transaction tx, long requestedPageNumber, int numberOfPages)
         {
-			Debug.Assert(Disposed == false);
+			ThrowObjectDisposedIfNeeded();
 
             if (requestedPageNumber + numberOfPages <= NumberOfAllocatedPages)
                 return;
@@ -126,15 +125,15 @@ namespace Voron.Impl.Paging
 
         public bool ShouldGoToOverflowPage(int len)
         {
-			Debug.Assert(Disposed == false);
+			ThrowObjectDisposedIfNeeded();
 			
             return len + Constants.PageHeaderSize > MaxNodeSize;
         }
 
         public int GetNumberOfOverflowPages(int overflowSize)
         {
-			Debug.Assert(Disposed == false);
-			
+			ThrowObjectDisposedIfNeeded();
+
             overflowSize += Constants.PageHeaderSize;
             return (overflowSize / PageSize) + (overflowSize % PageSize == 0 ? 0 : 1);
         }
@@ -145,19 +144,22 @@ namespace Voron.Impl.Paging
 
         public virtual void Dispose()
         {
-            if (PagerState != null)
-            {
-                PagerState.Release();
-                PagerState = null;
-            }
+            if (Disposed)
+                return;
 
-            Task.WaitAll(_tasks.ToArray());
+		    if (PagerState != null)
+		    {
+			    PagerState.Release();
+			    PagerState = null;
+		    }
 
-            Disposed = true;
-			GC.SuppressFinalize(this);
-        }
+		    Task.WaitAll(_tasks.ToArray());
 
-		~AbstractPager()
+		    Disposed = true;
+		    GC.SuppressFinalize(this);
+	    }
+
+	    ~AbstractPager()
 		{
 			Dispose();
 		}
@@ -204,5 +206,13 @@ namespace Voron.Impl.Paging
         {
             _tasks.Add(run);
         }
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		protected void ThrowObjectDisposedIfNeeded()
+		{
+			if (Disposed)
+				throw new ObjectDisposedException("The pager is already disposed");
+		}
+
     }
 }

--- a/Voron/Impl/Paging/FilePager.cs
+++ b/Voron/Impl/Paging/FilePager.cs
@@ -80,7 +80,8 @@ namespace Voron.Impl.Paging
 
 			Debug.Assert(_fileStream.Length == newLength);
 
-            PagerState.Release(); // when the last transaction using this is over, will dispose it
+			var tmp = PagerState;
+
             PagerState newPager = CreateNewPagerState();
 
             if (tx != null) // we only pass null during startup, and we don't need it there
@@ -90,6 +91,7 @@ namespace Voron.Impl.Paging
             }
 
             PagerState = newPager;
+			tmp.Release(); // when the last transaction using this is over, will dispose it
             NumberOfAllocatedPages = newLength / PageSize;
         }
 
@@ -184,6 +186,8 @@ namespace Voron.Impl.Paging
 
         public override void Dispose()
         {
+            if (Disposed)
+                return;
             base.Dispose();
       
             _fileStream.Dispose();

--- a/Voron/Impl/Paging/TemporaryPage.cs
+++ b/Voron/Impl/Paging/TemporaryPage.cs
@@ -38,7 +38,7 @@ namespace Voron.Impl.Paging
         {
             get
             {
-                return new Page((byte*)_tempPage.ToPointer(), "temp")
+                return new Page((byte*)_tempPage.ToPointer(), "temp", AbstractPager.PageSize)
                 {
                     Upper = AbstractPager.PageSize,
                     Lower = (ushort)Constants.PageHeaderSize,
@@ -46,6 +46,6 @@ namespace Voron.Impl.Paging
                 };
             }
         }
-
+	    public IDisposable ReturnTemporaryPageToPool { get; set; }
     }
 }

--- a/Voron/Impl/Paging/Win32PureMemoryPager.cs
+++ b/Voron/Impl/Paging/Win32PureMemoryPager.cs
@@ -110,6 +110,8 @@ namespace Voron.Impl.Paging
 
 		public override void Dispose()
 		{
+		    if (Disposed)
+		        return;
 			base.Dispose();
 		    for (ulong i = 0; i < _rangesCount; i++)
 		    {

--- a/Voron/Impl/ScratchBufferPool.cs
+++ b/Voron/Impl/ScratchBufferPool.cs
@@ -30,7 +30,7 @@ namespace Voron.Impl
         public ScratchBufferPool(StorageEnvironment env)
         {
             _scratchPager = env.Options.CreateScratchPager("scratch.buffers");
-            _scratchPager.AllocateMorePages(null, env.Options.InitialLogFileSize);
+            _scratchPager.AllocateMorePages(null, env.Options.InitialFileSize.HasValue ? Math.Max(env.Options.InitialFileSize.Value, env.Options.InitialLogFileSize) : env.Options.InitialLogFileSize);
         }
 
         public PagerState PagerState { get { return _scratchPager.PagerState; } }

--- a/Voron/Impl/SnapshotReader.cs
+++ b/Voron/Impl/SnapshotReader.cs
@@ -36,7 +36,7 @@
 						case WriteBatch.BatchOperationType.Add:
 					    {
 					        var reader = new ValueReader(stream);
-					        return new ReadResult(reader, version.HasValue ? (ushort)(version.Value + 1) : tree.ReadVersion(Transaction, key));
+					        return new ReadResult(reader, version.HasValue ? (ushort)(version.Value + 1) : tree.ReadVersion(key));
 					    }
 						case WriteBatch.BatchOperationType.Delete:
 							return null;
@@ -47,13 +47,13 @@
 		    if (tree == null) 
                 tree = GetTree(treeName);
 
-			return tree.Read(Transaction, key);
+			return tree.Read(key);
 		}
 
 		public int GetDataSize(string treeName, Slice key)
 		{
 			var tree = GetTree(treeName);
-			return tree.GetDataSize(Transaction, key);
+			return tree.GetDataSize(key);
 		}
 
 		public bool Contains(string treeName, Slice key, out ushort? version, WriteBatch writeBatch = null)
@@ -77,7 +77,7 @@
 			}
 
 			var tree = GetTree(treeName);
-			var readVersion = tree.ReadVersion(Transaction, key);
+			var readVersion = tree.ReadVersion(key);
 
 			var exists = readVersion > 0;
 
@@ -105,13 +105,13 @@
 			}
 
 			var tree = GetTree(treeName);
-			return tree.ReadVersion(Transaction, key);
+			return tree.ReadVersion(key);
 		}
 
 		public IIterator Iterate(string treeName, WriteBatch writeBatch = null)
 		{
 			var tree = GetTree(treeName);
-			return tree.Iterate(Transaction, writeBatch);
+			return tree.Iterate(writeBatch);
 		}
 
 		public void Dispose()
@@ -122,7 +122,7 @@
 		public IIterator MultiRead(string treeName, Slice key)
 		{
 			var tree = GetTree(treeName);
-			return tree.MultiRead(Transaction, key);
+			return tree.MultiRead(key);
 		}
 
 		private Tree GetTree(string treeName)

--- a/Voron/Impl/StorageEnvironmentState.cs
+++ b/Voron/Impl/StorageEnvironmentState.cs
@@ -23,12 +23,12 @@ namespace Voron
             NextPageNumber = nextPageNumber;
         }
 
-        public StorageEnvironmentState Clone()
+        public StorageEnvironmentState Clone(Transaction tx)
         {
-            return new StorageEnvironmentState()
+            return new StorageEnvironmentState
                 {
-                    Root = Root != null ? Root.Clone() : null,
-                    FreeSpaceRoot = FreeSpaceRoot != null ? FreeSpaceRoot.Clone() : null,
+					Root = Root != null ? Root.Clone(tx) : null,
+					FreeSpaceRoot = FreeSpaceRoot != null ? FreeSpaceRoot.Clone(tx) : null,
                     NextPageNumber = NextPageNumber
                 };
         }

--- a/Voron/Impl/TransactionMergingWriter.cs
+++ b/Voron/Impl/TransactionMergingWriter.cs
@@ -174,25 +174,25 @@ namespace Voron.Impl
 								case WriteBatch.BatchOperationType.Add:
 									var stream = operation.Value as Stream;
 									if (stream != null)
-										tree.Add(tx, operation.Key, stream, operation.Version);
+										tree.Add(operation.Key, stream, operation.Version);
 									else
-										tree.Add(tx, operation.Key, (Slice)operation.Value, operation.Version);
+										tree.Add(operation.Key, (Slice)operation.Value, operation.Version);
 									actionType = DebugActionType.Add;
 									break;
 								case WriteBatch.BatchOperationType.Delete:
-									tree.Delete(tx, operation.Key, operation.Version);
+									tree.Delete(operation.Key, operation.Version);
 									actionType = DebugActionType.Delete;
 									break;
 								case WriteBatch.BatchOperationType.MultiAdd:
-									tree.MultiAdd(tx, operation.Key, operation.Value as Slice, version: operation.Version);
+									tree.MultiAdd(operation.Key, operation.Value as Slice, version: operation.Version);
 									actionType = DebugActionType.MultiAdd;
 									break;
 								case WriteBatch.BatchOperationType.MultiDelete:
-									tree.MultiDelete(tx, operation.Key, operation.Value as Slice, operation.Version);
+									tree.MultiDelete(operation.Key, operation.Value as Slice, operation.Version);
 									actionType = DebugActionType.MultiDelete;
 									break;
 								case WriteBatch.BatchOperationType.Increment:
-									tree.Increment(tx, operation.Key, (long)operation.Value, operation.Version);
+									tree.Increment(operation.Key, (long)operation.Value, operation.Version);
 									actionType = DebugActionType.Increment;
 									break;
 								default:

--- a/Voron/Impl/TransactionMergingWriter.cs
+++ b/Voron/Impl/TransactionMergingWriter.cs
@@ -1,332 +1,382 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
 using Voron.Debugging;
-using Voron.Trees;
 using Voron.Util;
 
 namespace Voron.Impl
 {
-    using System;
-    using System.Collections.Concurrent;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.IO;
-    using System.Linq;
-    using System.Threading;
-    using Extensions;
+	public class TransactionMergingWriter : IDisposable
+	{
+		private readonly StorageEnvironment _env;
 
-    public class TransactionMergingWriter : IDisposable
-    {
-        private readonly StorageEnvironment _env;
+		private readonly CancellationToken _cancellationToken;
 
-        private readonly ConcurrentQueue<OutstandingWrite> _pendingWrites = new ConcurrentQueue<OutstandingWrite>();
-        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
-        private readonly ManualResetEventSlim _stopWrites = new ManualResetEventSlim();
-        private readonly ManualResetEventSlim _hasWrites = new ManualResetEventSlim();
-        private readonly DebugJournal _debugJournal;
-        private readonly ConcurrentQueue<ManualResetEventSlim> _eventsBuffer = new ConcurrentQueue<ManualResetEventSlim>();
+		private readonly ConcurrentQueue<OutstandingWrite> _pendingWrites = new ConcurrentQueue<OutstandingWrite>();
+		private readonly ManualResetEventSlim _stopWrites = new ManualResetEventSlim();
+		private readonly ManualResetEventSlim _hasWrites = new ManualResetEventSlim();
+		private readonly DebugJournal _debugJournal;
+		private readonly ConcurrentQueue<ManualResetEventSlim> _eventsBuffer = new ConcurrentQueue<ManualResetEventSlim>();
 
-        private bool ShouldRecordToDebugJournal
-        {
-            get
-            {
-                return _debugJournal != null && _debugJournal.IsRecording;
-            }
-        }
+		private bool ShouldRecordToDebugJournal
+		{
+			get
+			{
+				return _debugJournal != null && _debugJournal.IsRecording;
+			}
+		}
 
-        private readonly Lazy<Task> _backgroundTask;
+		private readonly Lazy<Task> _backgroundTask;
 
-        internal TransactionMergingWriter(StorageEnvironment env, DebugJournal debugJournal = null)
-        {
-            _env = env;
-            _stopWrites.Set();
-            _debugJournal = debugJournal;
-            _backgroundTask = new Lazy<Task>(() => Task.Factory.StartNew(BackgroundWriter, _cancellationTokenSource.Token,
-                                                                         TaskCreationOptions.LongRunning,
-                                                                         TaskScheduler.Current));
-        }
+		internal TransactionMergingWriter(StorageEnvironment env, CancellationToken cancellationToken, DebugJournal debugJournal = null)
+		{
+			_env = env;
+			_cancellationToken = cancellationToken;
+			_stopWrites.Set();
+			_debugJournal = debugJournal;
+			_backgroundTask = new Lazy<Task>(() => Task.Factory.StartNew(BackgroundWriter, _cancellationToken,
+																		 TaskCreationOptions.LongRunning,
+																		 TaskScheduler.Current));
+		}
 
-        public IDisposable StopWrites()
-        {
-            _stopWrites.Reset();
+		public IDisposable StopWrites()
+		{
+			_stopWrites.Reset();
 
-            return new DisposableAction(() => _stopWrites.Set());
-        }
+			return new DisposableAction(() => _stopWrites.Set());
+		}
 
-        public void Write(WriteBatch batch)
-        {
-            if (batch.IsEmpty)
-                return;
+		public void Write(WriteBatch batch)
+		{
+			if (batch.IsEmpty)
+				return;
 
-            EnsureValidBackgroundTaskState();
+			EnsureValidBackgroundTaskState();
 
-            using (var mine = new OutstandingWrite(batch, this))
-            {
-                _pendingWrites.Enqueue(mine);
+			using (var mine = new OutstandingWrite(batch, this))
+			{
+				_pendingWrites.Enqueue(mine);
 
-                _hasWrites.Set();
+				_hasWrites.Set();
 
-                mine.Wait();
-            }
-        }
+				mine.Wait();
+			}
+		}
 
-        private void EnsureValidBackgroundTaskState()
-        {
-            var backgroundTask = _backgroundTask.Value;
-            if (backgroundTask.IsCanceled || backgroundTask.IsFaulted)
-                backgroundTask.Wait(); // would throw
-            if (backgroundTask.IsCompleted)
-                throw new InvalidOperationException("The write background task has already completed!");
-        }
+		private void EnsureValidBackgroundTaskState()
+		{
+			var backgroundTask = _backgroundTask.Value;
+			if (backgroundTask.IsCanceled || backgroundTask.IsFaulted)
+				backgroundTask.Wait(); // would throw
+			if (backgroundTask.IsCompleted)
+				throw new InvalidOperationException("The write background task has already completed!");
+		}
 
-        private void BackgroundWriter()
-        {
-            var cancellationToken = _cancellationTokenSource.Token;
-            while (cancellationToken.IsCancellationRequested == false)
-            {
-                _stopWrites.Wait(cancellationToken);
-                _hasWrites.Reset();
+		private void BackgroundWriter()
+		{
+			while (_cancellationToken.IsCancellationRequested == false)
+			{
+				_cancellationToken.ThrowIfCancellationRequested();
 
-                OutstandingWrite write;
-                while (_pendingWrites.TryDequeue(out write))
-                {
-                    HandleActualWrites(write);
-                }
-                _hasWrites.Wait(cancellationToken);
-            }
-        }
+				_stopWrites.Wait(_cancellationToken);
+				_hasWrites.Reset();
 
-        private void HandleActualWrites(OutstandingWrite mine)
-        {
-            List<OutstandingWrite> writes = null;
-            try
-            {
-                writes = BuildBatchGroup(mine);
-                using (var tx = _env.NewTransaction(TransactionFlags.ReadWrite))
-                {
-                    HandleOperations(tx, writes.SelectMany(x => x.Batch.Operations));
+				OutstandingWrite write;
+				while (_pendingWrites.TryDequeue(out write))
+				{
+					HandleActualWrites(write, _cancellationToken);
+				}
+				_hasWrites.Wait(_cancellationToken);
+			}
+		}
 
-                    try
-                    {
-                        tx.Commit();
-                        if (ShouldRecordToDebugJournal)
-                            _debugJournal.Flush();
+		private void HandleActualWrites(OutstandingWrite mine, CancellationToken token)
+		{
+			List<OutstandingWrite> writes = null;
+			try
+			{
+				writes = BuildBatchGroup(mine);
+				using (var tx = _env.NewTransaction(TransactionFlags.ReadWrite))
+				{
+					HandleOperations(tx, writes, _cancellationToken);
 
-                        foreach (var write in writes)
-                            write.Completed();
-                    }
-                    catch (Exception e)
-                    {
-                        // if we have an error duing the commit, we can't recover, just fail them all.
-                        foreach (var write in writes)
-                        {
-                            write.Errored(e);
-                        }
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                HandleWriteFailure(writes, mine, e);
-            }
-        }
+					try
+					{
+						tx.Commit();
+						if (ShouldRecordToDebugJournal)
+							_debugJournal.Flush();
 
-        private void HandleWriteFailure(List<OutstandingWrite> writes, OutstandingWrite mine, Exception e)
-        {
-            if (writes == null || writes.Count == 0)
-            {
-                mine.Errored(e);
-                throw new InvalidOperationException("Couldn't get items to write", e);
-            }
+						foreach (var write in writes)
+							write.Completed();
+					}
+					catch (Exception e)
+					{
+						// if we have an error duing the commit, we can't recover, just fail them all.
+						foreach (var write in writes)
+						{
+							write.Errored(e);
+						}
+					}
+				}
+			}
+			catch (Exception e)
+			{
+				HandleWriteFailure(writes, mine, e);
+			}
+		}
 
-            if (writes.Count == 1)
-            {
-                writes[0].Errored(e);
-                return;
-            }
+		private void HandleWriteFailure(List<OutstandingWrite> writes, OutstandingWrite mine, Exception e)
+		{
+			if (writes == null || writes.Count == 0)
+			{
+				mine.Errored(e);
+				throw new InvalidOperationException("Couldn't get items to write", e);
+			}
 
-            SplitWrites(writes);
-        }
+			if (writes.Count == 1)
+			{
+				writes[0].Errored(e);
+				return;
+			}
 
-        private void HandleOperations(Transaction tx, IEnumerable<WriteBatch.BatchOperation> operations)
-        {
-            foreach (var g in operations.GroupBy(x => x.TreeName))
-            {
-                var tree = tx.State.GetTree(tx, g.Key);
-                // note that the ordering is done purely for performance reasons
-                // we rely on the fact that there can be only a single operation per key in
-                // each batch, and that we don't make any guarantees regarding ordering between
-                // concurrent merged writes
-                foreach (var operation in g.OrderBy(x => x.Key, SliceEqualityComparer.Instance))
-                {
-                    operation.Reset();
-                    DebugActionType actionType;
-                    switch (operation.Type)
-                    {
-                        case WriteBatch.BatchOperationType.Add:
-                            tree.Add(tx, operation.Key, operation.Value as Stream, operation.Version);
-                            actionType = DebugActionType.Add;
-                            break;
-                        case WriteBatch.BatchOperationType.Delete:
-                            tree.Delete(tx, operation.Key, operation.Version);
-                            actionType = DebugActionType.Delete;
-                            break;
-                        case WriteBatch.BatchOperationType.MultiAdd:
-                            tree.MultiAdd(tx, operation.Key, operation.Value as Slice, operation.Version);
-                            actionType = DebugActionType.MultiAdd;
-                            break;
-                        case WriteBatch.BatchOperationType.MultiDelete:
-                            tree.MultiDelete(tx, operation.Key, operation.Value as Slice, operation.Version);
-                            actionType = DebugActionType.MultiDelete;
-                            break;
-                        default:
-                            throw new ArgumentOutOfRangeException();
-                    }
+			SplitWrites(writes);
+		}
 
-                    if (ShouldRecordToDebugJournal)
-                        _debugJournal.RecordAction(actionType, operation.Key, g.Key, operation.Value);
+		private void HandleOperations(Transaction tx, List<OutstandingWrite> writes, CancellationToken token)
+		{
+			var trees = writes
+				.SelectMany(x => x.Trees)
+				.Distinct();
 
-                }
-            }
-        }
+			foreach (var treeName in trees)
+			{
+				token.ThrowIfCancellationRequested();
 
-        private void SplitWrites(List<OutstandingWrite> writes)
-        {
-            for (var index = 0; index < writes.Count; index++)
-            {
-                var write = writes[index];
-                try
-                {
-                    using (var tx = _env.NewTransaction(TransactionFlags.ReadWrite))
-                    {
-                        HandleOperations(tx, write.Batch.Operations);
-                        tx.Commit();
-                        write.Completed();
-                    }
-                }
-                catch (Exception e)
-                {
-                    write.Errored(e);
-                }
-            }
-        }
+				var tree = tx.State.GetTree(tx, treeName);
+				foreach (var write in writes)
+				{
+					foreach (var operation in write.GetOperations(treeName))
+					{
+						token.ThrowIfCancellationRequested();
 
-        private List<OutstandingWrite> BuildBatchGroup(OutstandingWrite mine)
-        {
-            // Allow the group to grow up to a maximum size, but if the
-            // original write is small, limit the growth so we do not slow
-            // down the small write too much.
-            long maxSize = 16 * 1024 * 1024; // 16 MB by default
-            if (mine.Size < 128 * 1024)
-                maxSize = (1024 * 1024); // 1 MB if small
+						operation.Reset();
 
-            var list = new List<OutstandingWrite> { mine };
+						try
+						{
+							DebugActionType actionType;
+							switch (operation.Type)
+							{
+								case WriteBatch.BatchOperationType.Add:
+									var stream = operation.Value as Stream;
+									if (stream != null)
+										tree.Add(tx, operation.Key, stream, operation.Version);
+									else
+										tree.Add(tx, operation.Key, (Slice)operation.Value, operation.Version);
+									actionType = DebugActionType.Add;
+									break;
+								case WriteBatch.BatchOperationType.Delete:
+									tree.Delete(tx, operation.Key, operation.Version);
+									actionType = DebugActionType.Delete;
+									break;
+								case WriteBatch.BatchOperationType.MultiAdd:
+									tree.MultiAdd(tx, operation.Key, operation.Value as Slice, version: operation.Version);
+									actionType = DebugActionType.MultiAdd;
+									break;
+								case WriteBatch.BatchOperationType.MultiDelete:
+									tree.MultiDelete(tx, operation.Key, operation.Value as Slice, operation.Version);
+									actionType = DebugActionType.MultiDelete;
+									break;
+								case WriteBatch.BatchOperationType.Increment:
+									tree.Increment(tx, operation.Key, (long)operation.Value, operation.Version);
+									actionType = DebugActionType.Increment;
+									break;
+								default:
+									throw new ArgumentOutOfRangeException();
+							}
 
-            maxSize -= mine.Size;
+							if (ShouldRecordToDebugJournal)
+								_debugJournal.RecordAction(actionType, operation.Key, treeName, operation.Value);
+						}
+						catch (Exception e)
+						{
+							if (operation.ExceptionTypesToIgnore.Contains(e.GetType()) == false)
+								throw;
+						}
+					}
+				}
+			}
+		}
 
-            while (true)
-            {
-                if (maxSize <= 0)
-                    break;
+		private void SplitWrites(List<OutstandingWrite> writes)
+		{
+			for (var index = 0; index < writes.Count; index++)
+			{
+				var write = writes[index];
+				try
+				{
+					_cancellationToken.ThrowIfCancellationRequested();
 
-                OutstandingWrite item;
-                if (_pendingWrites.TryDequeue(out item) == false)
-                    break;
-                list.Add(item);
-                maxSize -= item.Size;
-            }
+					using (var tx = _env.NewTransaction(TransactionFlags.ReadWrite))
+					{
+						HandleOperations(tx, new List<OutstandingWrite> { write }, _cancellationToken);
+						tx.Commit();
+						write.Completed();
+					}
+				}
+				catch (Exception e)
+				{
+					write.Errored(e);
+				}
+			}
+		}
 
-            return list;
-        }
+		private List<OutstandingWrite> BuildBatchGroup(OutstandingWrite mine)
+		{
+			// Allow the group to grow up to a maximum size, but if the
+			// original write is small, limit the growth so we do not slow
+			// down the small write too much.
+			long maxSize = 64 * 1024 * 1024; // 64 MB by default
+			if (mine.Size < 128 * 1024)
+				maxSize = (2 * 1024 * 1024); // 2 MB if small
 
-        private class OutstandingWrite : IDisposable
-        {
-            private readonly TransactionMergingWriter _transactionMergingWriter;
-            private Exception _exception;
-            private readonly ManualResetEventSlim _completed;
+			var list = new List<OutstandingWrite> { mine };
 
-            public OutstandingWrite(WriteBatch batch, TransactionMergingWriter transactionMergingWriter)
-            {
-                _transactionMergingWriter = transactionMergingWriter;
-                Batch = batch;
-                Size = batch.Size();
+			maxSize -= mine.Size;
 
-                if (transactionMergingWriter._eventsBuffer.TryDequeue(out _completed) == false)
-                    _completed = new ManualResetEventSlim();
-                _completed.Reset();
-            }
+			while (true)
+			{
+				if (maxSize <= 0)
+					break;
 
-            public WriteBatch Batch { get; private set; }
+				OutstandingWrite item;
+				if (_pendingWrites.TryDequeue(out item) == false)
+					break;
+				list.Add(item);
+				maxSize -= item.Size;
+			}
 
-            public long Size { get; private set; }
+			return list;
+		}
 
-            public void Dispose()
-            {
-				if(Batch.DisposeAfterWrite)
-					Batch.Dispose();
+		private class OutstandingWrite : IDisposable
+		{
+			private readonly WriteBatch _batch;
 
-                _transactionMergingWriter._eventsBuffer.Enqueue(_completed);
-            }
+			private readonly TransactionMergingWriter _transactionMergingWriter;
+			private Exception _exception;
+			private readonly ManualResetEventSlim _completed;
 
-            public void Errored(Exception e)
-            {
-                var wasSet = _completed.IsSet;
+			private readonly Dictionary<string, List<WriteBatch.BatchOperation>> _operations = new Dictionary<string, List<WriteBatch.BatchOperation>>(); 
 
-                _exception = e;
-                _completed.Set();
+			public OutstandingWrite(WriteBatch batch, TransactionMergingWriter transactionMergingWriter)
+			{
+				_batch = batch;
+				_transactionMergingWriter = transactionMergingWriter;
 
-                if (wasSet)
-                    throw new InvalidOperationException("This should not happen.");
-            }
+				_operations = CreateOperations(batch);
+				Size = batch.Size();
 
-            public void Completed()
-            {
-                var wasSet = _completed.IsSet;
-                _completed.Set();
+				if (transactionMergingWriter._eventsBuffer.TryDequeue(out _completed) == false)
+					_completed = new ManualResetEventSlim();
+				_completed.Reset();
+			}
 
-                if (wasSet)
-                    throw new InvalidOperationException("This should not happen.");
-            }
+			private static Dictionary<string, List<WriteBatch.BatchOperation>> CreateOperations(WriteBatch batch)
+			{
+				return batch.Trees.ToDictionary(tree => tree, tree => batch.GetSortedOperations(tree).ToList());
+			}
 
-            public void Wait()
-            {
-                _completed.Wait();
-                if (_exception != null)
-                {
-                    throw new AggregateException("Error when executing write", _exception);
-                }
-            }
-        }
+			public IEnumerable<string> Trees
+			{
+				get
+				{
+					return _batch.Trees;
+				}
+			} 
 
-        public void Dispose()
-        {
-            _cancellationTokenSource.Cancel();
-            _stopWrites.Set();
-            _hasWrites.Set();
+			public IEnumerable<WriteBatch.BatchOperation> GetOperations(string treeName)
+			{
+				List<WriteBatch.BatchOperation> operations;
+				if (_operations.TryGetValue(treeName, out operations))
+					return operations;
 
-            try
-            {
-                if (_backgroundTask.IsValueCreated == false)
-                    return;
-                _backgroundTask.Value.Wait();
-            }
-            catch (TaskCanceledException)
-            {
-            }
-            catch (AggregateException e)
-            {
-                if (e.InnerException is TaskCanceledException)
-                    return;
-                throw;
-            }
-            finally
-            {
-                foreach (var manualResetEventSlim in _eventsBuffer)
-                {
-                    manualResetEventSlim.Dispose();
-                }
-                _stopWrites.Dispose();
-                _hasWrites.Dispose();
-            }
-        }
-    }
+				return Enumerable.Empty<WriteBatch.BatchOperation>();
+			}
+
+			public long Size { get; private set; }
+
+			public void Dispose()
+			{
+				if (_batch.DisposeAfterWrite)
+					_batch.Dispose();
+
+				_transactionMergingWriter._eventsBuffer.Enqueue(_completed);
+			}
+
+			public void Errored(Exception e)
+			{
+				var wasSet = _completed.IsSet;
+
+				_exception = e;
+				_completed.Set();
+
+				if (wasSet)
+					throw new InvalidOperationException("This should not happen.");
+			}
+
+			public void Completed()
+			{
+				var wasSet = _completed.IsSet;
+				_completed.Set();
+
+				if (wasSet)
+					throw new InvalidOperationException("This should not happen.");
+			}
+
+			public void Wait()
+			{
+				_completed.Wait();
+				if (_exception != null)
+				{
+					throw new AggregateException("Error when executing write", _exception);
+				}
+			}
+		}
+
+		public void Dispose()
+		{
+			_stopWrites.Set();
+			_hasWrites.Set();
+
+			try
+			{
+				if (_backgroundTask.IsValueCreated == false)
+					return;
+				_backgroundTask.Value.Wait();
+			}
+			catch (TaskCanceledException)
+			{
+			}
+			catch (AggregateException e)
+			{
+				if (e.InnerException is TaskCanceledException || e.InnerException is OperationCanceledException)
+					return;
+				throw;
+			}
+			finally
+			{
+				foreach (var manualResetEventSlim in _eventsBuffer)
+				{
+					manualResetEventSlim.Dispose();
+				}
+				_stopWrites.Dispose();
+				_hasWrites.Dispose();
+			}
+		}
+	}
 }

--- a/Voron/Impl/WriteBatch.cs
+++ b/Voron/Impl/WriteBatch.cs
@@ -1,55 +1,69 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+using Voron.Exceptions;
 
 namespace Voron.Impl
 {
-	using System;
-	using System.Collections.Generic;
-	using System.IO;
-	using System.Linq;
-
 	public class WriteBatch : IDisposable
 	{
 		private readonly Dictionary<string, Dictionary<Slice, BatchOperation>> _lastOperations;
 		private readonly Dictionary<string, Dictionary<Slice, List<BatchOperation>>> _multiTreeOperations;
 
+		private readonly HashSet<string> _trees = new HashSet<string>(); 
+
 		private readonly SliceEqualityComparer _sliceEqualityComparer;
 		private bool _disposeAfterWrite = true;
 
-		public IEnumerable<BatchOperation> Operations
+		public HashSet<string> Trees
 		{
 			get
 			{
-				var allOperations = _lastOperations.SelectMany(x => x.Value.Values);
-
-				if (_multiTreeOperations.Count == 0)
-					return allOperations;
-
-				return allOperations.Concat(_multiTreeOperations.SelectMany(x => x.Value.Values)
-												.SelectMany(x => x));
+				return _trees;
 			}
 		}
 
-		public Func<long> Size
+		public IEnumerable<BatchOperation> GetSortedOperations(string treeName)
 		{
-			get
+			Dictionary<Slice, BatchOperation> operations;
+			if (_lastOperations.TryGetValue(treeName, out operations))
 			{
-				return () =>
-				{
-					long totalSize = 0;
-
-					if (_lastOperations.Count > 0)
-						totalSize += _lastOperations.Sum(
-							operation =>
-							operation.Value.Values.Sum(x => x.Type == BatchOperationType.Add ? x.ValueSize + x.Key.Size : x.Key.Size));
-
-					if (_multiTreeOperations.Count > 0)
-						totalSize += _multiTreeOperations.Sum(
-							tree =>
-							tree.Value.Sum(
-								multiOp => multiOp.Value.Sum(x => x.Type == BatchOperationType.Add ? x.ValueSize + x.Key.Size : x.Key.Size)));
-					return totalSize;
-				};
+				foreach (var operation in operations.OrderBy(x => x.Key, _sliceEqualityComparer))
+					yield return operation.Value;
 			}
+
+			if (_multiTreeOperations.Count == 0)
+				yield break;
+
+			Dictionary<Slice, List<BatchOperation>> multiOperations;
+			if (_multiTreeOperations.TryGetValue(treeName, out multiOperations) == false)
+				yield break;
+
+			foreach (var operation in multiOperations
+				.OrderBy(x => x.Key, _sliceEqualityComparer)
+				.SelectMany(x => x.Value)
+				.OrderBy(x => (Slice)x.Value, _sliceEqualityComparer))
+				yield return operation;
+		}
+
+		public long Size()
+		{
+			long totalSize = 0;
+
+			if (_lastOperations.Count > 0)
+				totalSize += _lastOperations.Sum(
+					operation =>
+					operation.Value.Values.Sum(x => x.Type == BatchOperationType.Add ? x.ValueSize + x.Key.Size : x.Key.Size));
+
+			if (_multiTreeOperations.Count > 0)
+				totalSize += _multiTreeOperations.Sum(
+					tree =>
+					tree.Value.Sum(
+						multiOp => multiOp.Value.Sum(x => x.Type == BatchOperationType.Add ? x.ValueSize + x.Key.Size : x.Key.Size)));
+			return totalSize;
 		}
 
 		public bool IsEmpty { get { return _lastOperations.Count == 0 && _multiTreeOperations.Count == 0; } }
@@ -112,61 +126,86 @@ namespace Voron.Impl
 			_sliceEqualityComparer = new SliceEqualityComparer();
 		}
 
-		public void Add(Slice key, Stream value, string treeName, ushort? version = null)
+		public void Add(Slice key, Slice value, string treeName, ushort? version = null, bool shouldIgnoreConcurrencyExceptions = false)
 		{
-			if (treeName != null && treeName.Length == 0) throw new ArgumentException("treeName must not be empty", "treeName");
+			AssertValidTreeName(treeName);
 			if (value == null) throw new ArgumentNullException("value");
-			//TODO : check up if adding empty values make sense in Voron --> in order to be consistent with existing behavior of Esent, this should be allowed
-			//			if (value.Length == 0)
-			//				throw new ArgumentException("Cannot add empty value");
+
+			var batchOperation = BatchOperation.Add(key, value, version, treeName);
+			if (shouldIgnoreConcurrencyExceptions)
+				batchOperation.SetIgnoreExceptionOnExecution<ConcurrencyException>();
+			AddOperation(batchOperation);
+		}
+
+		public void Add(Slice key, Stream value, string treeName, ushort? version = null, bool shouldIgnoreConcurrencyExceptions = false)
+		{
+			AssertValidTreeName(treeName);
+			if (value == null) throw new ArgumentNullException("value");
 			if (value.Length > int.MaxValue)
 				throw new ArgumentException("Cannot add a value that is over 2GB in size", "value");
 
-
-			AddOperation(new BatchOperation(key, value, version, treeName, BatchOperationType.Add));
+			var batchOperation = BatchOperation.Add(key, value, version, treeName);
+			if (shouldIgnoreConcurrencyExceptions)
+				batchOperation.SetIgnoreExceptionOnExecution<ConcurrencyException>();
+			AddOperation(batchOperation);
 		}
 
 		public void Delete(Slice key, string treeName, ushort? version = null)
 		{
 			AssertValidRemove(treeName);
 
-			AddOperation(new BatchOperation(key, null as Stream, version, treeName, BatchOperationType.Delete));
+			AddOperation(BatchOperation.Delete(key, version, treeName));
 		}
 
 		private static void AssertValidRemove(string treeName)
 		{
-			if (treeName != null && treeName.Length == 0) throw new ArgumentException("treeName must not be empty", "treeName");
+			AssertValidTreeName(treeName);
 		}
 
 		public void MultiAdd(Slice key, Slice value, string treeName, ushort? version = null)
 		{
 			AssertValidMultiOperation(value, treeName);
 
-			AddOperation(new BatchOperation(key, value, version, treeName, BatchOperationType.MultiAdd));
-		}
-
-		private static void AssertValidMultiOperation(Slice value, string treeName)
-		{
-			if (treeName != null && treeName.Length == 0) throw new ArgumentException("treeName must not be empty", "treeName");
-			if (value == null) throw new ArgumentNullException("value");
-			if (value.Size == 0)
-				throw new ArgumentException("Cannot add empty value");
+			AddOperation(BatchOperation.MultiAdd(key, value, version, treeName));
 		}
 
 		public void MultiDelete(Slice key, Slice value, string treeName, ushort? version = null)
 		{
 			AssertValidMultiOperation(value, treeName);
 
-			AddOperation(new BatchOperation(key, value, version, treeName, BatchOperationType.MultiDelete));
+			AddOperation(BatchOperation.MultiDelete(key, value, version, treeName));
+		}
+
+		public void Increment(Slice key, long delta, string treeName, ushort? version = null)
+		{
+			AssertValidTreeName(treeName);
+
+			AddOperation(BatchOperation.Increment(key, delta, version, treeName));
+		}
+
+		private static void AssertValidTreeName(string treeName)
+		{
+			if (treeName != null && treeName.Length == 0) 
+				throw new ArgumentException("treeName must not be empty", "treeName");
+		}
+
+		private static void AssertValidMultiOperation(Slice value, string treeName)
+		{
+			AssertValidTreeName(treeName);
+			if (value == null) throw new ArgumentNullException("value");
+			if (value.Size == 0)
+				throw new ArgumentException("Cannot add empty value");
 		}
 
 		private void AddOperation(BatchOperation operation)
 		{
 			var treeName = operation.TreeName;
-			if (treeName != null && treeName.Length == 0) throw new ArgumentException("treeName must not be empty", "treeName");
+			AssertValidTreeName(treeName);
 
 			if (treeName == null)
 				treeName = Constants.RootTreeName;
+
+			_trees.Add(treeName);
 
 			if (operation.Type == BatchOperationType.MultiAdd || operation.Type == BatchOperationType.MultiDelete)
 			{
@@ -202,13 +241,52 @@ namespace Voron.Impl
 			}
 		}
 
-		public class BatchOperation
+		public class BatchOperation : IComparable<BatchOperation>
 		{
+#if DEBUG
+			private readonly StackTrace stackTrace;
+			public StackTrace StackTrace
+			{
+				get { return stackTrace; }
+			}
+#endif
+
 			private readonly long originalStreamPosition;
-
+			private readonly HashSet<Type> exceptionTypesToIgnore = new HashSet<Type>();
 			private readonly Action reset = delegate { };
+			private readonly Slice valSlice;
 
-			public BatchOperation(Slice key, Stream value, ushort? version, string treeName, BatchOperationType type)
+			public static BatchOperation Add(Slice key, Slice value, ushort? version, string treeName)
+			{
+				return new BatchOperation(key, value, version, treeName, BatchOperationType.Add);
+			}
+
+			public static BatchOperation Add(Slice key, Stream stream, ushort? version, string treeName)
+			{
+				return new BatchOperation(key, stream, version, treeName, BatchOperationType.Add);
+			}
+
+			public static BatchOperation Delete(Slice key, ushort? version, string treeName)
+			{
+				return new BatchOperation(key, null as Stream, version, treeName, BatchOperationType.Delete);
+			}
+
+			public static BatchOperation MultiAdd(Slice key, Slice value, ushort? version, string treeName)
+			{
+				return new BatchOperation(key, value, version, treeName, BatchOperationType.MultiAdd);
+			}
+
+			public static BatchOperation MultiDelete(Slice key, Slice value, ushort? version, string treeName)
+			{
+				return new BatchOperation(key, value, version, treeName, BatchOperationType.MultiDelete);
+			}
+
+			public static BatchOperation Increment(Slice key, long delta, ushort? version, string treeName)
+			{
+				return new BatchOperation(key, delta, version, treeName, BatchOperationType.Increment);
+			}
+
+			private BatchOperation(Slice key, Stream value, ushort? version, string treeName, BatchOperationType type)
 				: this(key, value as object, version, treeName, type)
 			{
 				if (value != null)
@@ -218,13 +296,18 @@ namespace Voron.Impl
 
 					reset = () => value.Position = originalStreamPosition;
 				}
+
+#if DEBUG
+				stackTrace = new StackTrace();
+#endif
 			}
 
-			public BatchOperation(Slice key, Slice value, ushort? version, string treeName, BatchOperationType type)
+			private BatchOperation(Slice key, Slice value, ushort? version, string treeName, BatchOperationType type)
 				: this(key, value as object, version, treeName, type)
 			{
 				if (value != null)
 				{
+					valSlice = value;
 					originalStreamPosition = 0;
 					ValueSize = value.Size;
 				}
@@ -251,6 +334,12 @@ namespace Voron.Impl
 
 			public ushort? Version { get; private set; }
 
+			public HashSet<Type> ExceptionTypesToIgnore
+			{
+				get { return exceptionTypesToIgnore; }
+			}
+
+
 			public void SetVersionFrom(BatchOperation other)
 			{
 				if (other.Version != null &&
@@ -262,6 +351,30 @@ namespace Voron.Impl
 			{
 				reset();
 			}
+
+			public void SetIgnoreExceptionOnExecution<T>()
+				where T : Exception
+			{
+				ExceptionTypesToIgnore.Add(typeof(T));
+			}
+
+			public unsafe int CompareTo(BatchOperation other)
+			{
+				var r = SliceEqualityComparer.Instance.Compare(Key, other.Key);
+				if (r != 0)
+					return r;
+				if (valSlice != null)
+				{
+					if (other.valSlice == null)
+						return -1;
+					return valSlice.Compare(other.valSlice, NativeMethods.memcmp);
+				}
+				else if (other.valSlice != null)
+				{
+					return 1;
+				}
+				return 0;
+			}
 		}
 
 		public enum BatchOperationType
@@ -271,6 +384,7 @@ namespace Voron.Impl
 			Delete = 2,
 			MultiAdd = 3,
 			MultiDelete = 4,
+			Increment = 5
 		}
 
 		public void Dispose()

--- a/Voron/Impl/WriteBatch.cs
+++ b/Voron/Impl/WriteBatch.cs
@@ -10,9 +10,10 @@ namespace Voron.Impl
 	public class WriteBatch : IDisposable
 	{
 		private readonly Dictionary<string, Dictionary<Slice, BatchOperation>> _lastOperations;
-		private readonly Dictionary<string, Dictionary<Slice, List<BatchOperation>>>  _multiTreeOperations;
+		private readonly Dictionary<string, Dictionary<Slice, List<BatchOperation>>> _multiTreeOperations;
 
 		private readonly SliceEqualityComparer _sliceEqualityComparer;
+		private bool _disposeAfterWrite = true;
 
 		public IEnumerable<BatchOperation> Operations
 		{
@@ -28,62 +29,59 @@ namespace Voron.Impl
 			}
 		}
 
-	    public int OperationsCount
-	    {
-	        get
-	        {
-	            return _lastOperations.Sum(x => x.Value.Count) +
-	                   _multiTreeOperations.Sum(x => x.Value.Sum(y => y.Value.Count));
-	        }
-	    }
-
 		public Func<long> Size
 		{
 			get
 			{
 				return () =>
-					{
-						long totalSize = 0;
+				{
+					long totalSize = 0;
 
-						if (_lastOperations.Count > 0)
-							totalSize += _lastOperations.Sum(
-								operation =>
-								operation.Value.Values.Sum(x => x.Type == BatchOperationType.Add ? x.ValueSize + x.Key.Size : x.Key.Size));
+					if (_lastOperations.Count > 0)
+						totalSize += _lastOperations.Sum(
+							operation =>
+							operation.Value.Values.Sum(x => x.Type == BatchOperationType.Add ? x.ValueSize + x.Key.Size : x.Key.Size));
 
-						if (_multiTreeOperations.Count > 0)
-							totalSize += _multiTreeOperations.Sum(
-								tree =>
-								tree.Value.Sum(
-									multiOp => multiOp.Value.Sum(x => x.Type == BatchOperationType.Add ? x.ValueSize + x.Key.Size : x.Key.Size)));
-						return totalSize;
-					};
+					if (_multiTreeOperations.Count > 0)
+						totalSize += _multiTreeOperations.Sum(
+							tree =>
+							tree.Value.Sum(
+								multiOp => multiOp.Value.Sum(x => x.Type == BatchOperationType.Add ? x.ValueSize + x.Key.Size : x.Key.Size)));
+					return totalSize;
+				};
 			}
 		}
 
 		public bool IsEmpty { get { return _lastOperations.Count == 0 && _multiTreeOperations.Count == 0; } }
 
-	    internal bool TryGetValue(string treeName, Slice key, out Stream value, out ushort? version, out BatchOperationType operationType)
+		public bool DisposeAfterWrite
 		{
-		    value = null;
-		    version = null;
+			get { return _disposeAfterWrite; }
+			set { _disposeAfterWrite = value; }
+		}
+
+		internal bool TryGetValue(string treeName, Slice key, out Stream value, out ushort? version, out BatchOperationType operationType)
+		{
+			value = null;
+			version = null;
 			operationType = BatchOperationType.None;
 
 			if (treeName == null)
 				treeName = Constants.RootTreeName;
 
 			//first check if it is a multi-tree operation
-		    Dictionary<Slice, List<BatchOperation>> treeOperations;
-		    if (_multiTreeOperations.TryGetValue(treeName, out treeOperations))
-		    {
-                List<BatchOperation> operationRecords;
-			    if (treeOperations.TryGetValue(key, out operationRecords))
-			    {
+			Dictionary<Slice, List<BatchOperation>> treeOperations;
+			if (_multiTreeOperations.TryGetValue(treeName, out treeOperations))
+			{
+				List<BatchOperation> operationRecords;
+				if (treeOperations.TryGetValue(key, out operationRecords))
+				{
 					//since in multi-tree there are many operations for single tree key, then fetching operation type and value is meaningless
-				    return true;
-			    }				
-		    }
+					return true;
+				}
+			}
 
-		    Dictionary<Slice, BatchOperation> operations;
+			Dictionary<Slice, BatchOperation> operations;
 			if (_lastOperations.TryGetValue(treeName, out operations) == false)
 				return false;
 
@@ -91,12 +89,13 @@ namespace Voron.Impl
 			if (operations.TryGetValue(key, out operation))
 			{
 				operationType = operation.Type;
-			    version = operation.Version;
+				version = operation.Version;
 
 				if (operation.Type == BatchOperationType.Delete)
 					return true;
 
-			    value = operation.Value as Stream;
+				value = operation.Value as Stream;
+				operation.Reset(); // will reset stream position
 
 				if (operation.Type == BatchOperationType.Add)
 					return true;
@@ -109,7 +108,7 @@ namespace Voron.Impl
 		public WriteBatch()
 		{
 			_lastOperations = new Dictionary<string, Dictionary<Slice, BatchOperation>>();
-            _multiTreeOperations = new Dictionary<string, Dictionary<Slice, List<BatchOperation>>>();
+			_multiTreeOperations = new Dictionary<string, Dictionary<Slice, List<BatchOperation>>>();
 			_sliceEqualityComparer = new SliceEqualityComparer();
 		}
 
@@ -171,16 +170,16 @@ namespace Voron.Impl
 
 			if (operation.Type == BatchOperationType.MultiAdd || operation.Type == BatchOperationType.MultiDelete)
 			{
-                Dictionary<Slice, List<BatchOperation>> multiTreeOperationsOfTree;
+				Dictionary<Slice, List<BatchOperation>> multiTreeOperationsOfTree;
 				if (_multiTreeOperations.TryGetValue(treeName, out multiTreeOperationsOfTree) == false)
 				{
 					_multiTreeOperations[treeName] =
-                        multiTreeOperationsOfTree = new Dictionary<Slice, List<BatchOperation>>(_sliceEqualityComparer);
+						multiTreeOperationsOfTree = new Dictionary<Slice, List<BatchOperation>>(_sliceEqualityComparer);
 				}
 
-                List<BatchOperation> specificMultiTreeOperations;
+				List<BatchOperation> specificMultiTreeOperations;
 				if (multiTreeOperationsOfTree.TryGetValue(operation.Key, out specificMultiTreeOperations) == false)
-                    multiTreeOperationsOfTree[operation.Key] = specificMultiTreeOperations = new List<BatchOperation>();
+					multiTreeOperationsOfTree[operation.Key] = specificMultiTreeOperations = new List<BatchOperation>();
 
 				specificMultiTreeOperations.Add(operation);
 			}
@@ -254,7 +253,7 @@ namespace Voron.Impl
 
 			public void SetVersionFrom(BatchOperation other)
 			{
-				if (other.Version != null && 
+				if (other.Version != null &&
 					other.Version + 1 == Version)
 					Version = other.Version;
 			}

--- a/Voron/SliceWriter.cs
+++ b/Voron/SliceWriter.cs
@@ -1,0 +1,40 @@
+using System.Text;
+using Voron.Util.Conversion;
+
+namespace Voron
+{
+    public struct SliceWriter
+    {
+        private int _pos;
+        private readonly byte[] _buffer;
+
+        public SliceWriter(int size)
+        {
+            _pos = 0;
+            _buffer = new byte[size];
+        }
+
+        public void WriteBigEndian(int i)
+        {
+            EndianBitConverter.Big.CopyBytes(i, _buffer, _pos);
+            _pos += sizeof (int);
+        }
+
+        public void WriteBigEndian(long l)
+        {
+            EndianBitConverter.Big.CopyBytes(l, _buffer, _pos);
+            _pos += sizeof(long);
+        }
+
+        public void WriteBigEndian(short s)
+        {
+            EndianBitConverter.Big.CopyBytes(s, _buffer, _pos);
+            _pos += sizeof(short);
+        }
+
+        public Slice CreateSlice()
+        {
+            return new Slice(_buffer);
+        }
+    }
+}

--- a/Voron/StorageEnvironment.cs
+++ b/Voron/StorageEnvironment.cs
@@ -233,12 +233,12 @@ namespace Voron
 	        if (tree == null)
 	            return;
 
-            foreach (var page in tree.AllPages(tx))
+            foreach (var page in tree.AllPages())
             {
                 tx.FreePage(page);
             }
 
-            tx.State.Root.Delete(tx, name);
+            tx.State.Root.Delete(name);
 
             tx.RemoveTree(name);
         }
@@ -255,7 +255,7 @@ namespace Voron
             Slice key = name;
 
             // we are in a write transaction, no need to handle locks
-            var header = (TreeRootHeader*)tx.State.Root.DirectRead(tx, key);
+            var header = (TreeRootHeader*)tx.State.Root.DirectRead(key);
             if (header != null)
             {
                 tree = Tree.Open(tx, _sliceComparer, header);
@@ -266,7 +266,7 @@ namespace Voron
 
             tree = Tree.Create(tx, _sliceComparer);
             tree.Name = name;
-            var space = tx.State.Root.DirectAdd(tx, key, sizeof(TreeRootHeader));
+            var space = tx.State.Root.DirectAdd(key, sizeof(TreeRootHeader));
 
             tree.State.CopyTo((TreeRootHeader*)space);
             tree.State.IsModified = true;
@@ -438,14 +438,14 @@ namespace Voron
         {
             var results = new Dictionary<string, List<long>>(StringComparer.OrdinalIgnoreCase)
 				{
-					{"Root", State.Root.AllPages(tx)},
-					{"Free Space Overhead", State.FreeSpaceRoot.AllPages(tx)},
+					{"Root", State.Root.AllPages()},
+					{"Free Space Overhead", State.FreeSpaceRoot.AllPages()},
 					{"Free Pages", _freeSpaceHandling.AllPages(tx)}
 				};
 
             foreach (var tree in tx.Trees)
             {
-                results.Add(tree.Name, tree.AllPages(tx));
+                results.Add(tree.Name, tree.AllPages());
             }
 
             return results;

--- a/Voron/StorageEnvironment.cs
+++ b/Voron/StorageEnvironment.cs
@@ -461,12 +461,16 @@ namespace Voron
 
         public EnvironmentStats Stats()
         {
+            var numberOfAllocatedPages = Math.Max(_dataPager.NumberOfAllocatedPages, State.NextPageNumber - 1); // async apply to data file task
+
             return new EnvironmentStats
                 {
                     FreePages = _freeSpaceHandling.GetFreePageCount(),
                     FreePagesOverhead = State.FreeSpaceRoot.State.PageCount,
                     RootPages = State.Root.State.PageCount,
-                    UnallocatedPagesAtEndOfFile = _dataPager.NumberOfAllocatedPages - NextPageNumber
+                    UnallocatedPagesAtEndOfFile = _dataPager.NumberOfAllocatedPages - NextPageNumber,
+                    UsedDataFileSizeInBytes = (State.NextPageNumber - 1) * AbstractPager.PageSize,
+                    AllocatedDataFileSizeInBytes = numberOfAllocatedPages * AbstractPager.PageSize
                 };
         }
 

--- a/Voron/StorageEnvironmentOptions.cs
+++ b/Voron/StorageEnvironmentOptions.cs
@@ -28,6 +28,8 @@ namespace Voron
 			handler(this, new RecoveryErrorEventArgs(message, e));
 		}
 
+		public long? InitialFileSize { get; set; }
+
 		public long MaxLogFileSize
 		{
 			get { return _maxLogFileSize; }
@@ -63,6 +65,7 @@ namespace Voron
 		public int IdleFlushTimeout { get; set; }
 
 		public long? MaxStorageSize { get; set; }
+		public abstract string BasePath { get; }
 
 		public abstract IJournalWriter CreateJournalWriter(long journalNumber, long journalSize);
 
@@ -89,9 +92,9 @@ namespace Voron
 			return new PureMemoryStorageEnvironmentOptions();
 		}		
 
-		public static StorageEnvironmentOptions ForPath(string path, string tempPath = null)
+		public static StorageEnvironmentOptions ForPath(string path, string tempPath = null, string journalPath = null)
 		{
-            return new DirectoryStorageEnvironmentOptions(path, tempPath);
+            return new DirectoryStorageEnvironmentOptions(path, tempPath, journalPath);
 		}
 
 		public IDisposable AllowManualFlushing()
@@ -105,7 +108,8 @@ namespace Voron
 
 		public class DirectoryStorageEnvironmentOptions : StorageEnvironmentOptions
 		{
-			private readonly string _basePath;
+		    private readonly string _journalPath;
+		    private readonly string _basePath;
             private readonly string _tempPath;
 
 			private readonly Lazy<IVirtualPager> _dataPager;
@@ -113,18 +117,22 @@ namespace Voron
 			private readonly ConcurrentDictionary<string, Lazy<IJournalWriter>> _journals =
 				new ConcurrentDictionary<string, Lazy<IJournalWriter>>(StringComparer.OrdinalIgnoreCase);
 
-			public DirectoryStorageEnvironmentOptions(string basePath, string tempPath)
+			public DirectoryStorageEnvironmentOptions(string basePath, string tempPath, string journalPath)
 			{
-				_basePath = Path.GetFullPath(basePath);
+			    _basePath = Path.GetFullPath(basePath);
                 _tempPath = !string.IsNullOrEmpty(tempPath) ? Path.GetFullPath(tempPath) : _basePath;
-
+			    _journalPath = !string.IsNullOrEmpty(journalPath) ? Path.GetFullPath(journalPath) : _basePath;
+                
 				if (Directory.Exists(_basePath) == false)
 					Directory.CreateDirectory(_basePath);
 
                 if (_basePath != tempPath && Directory.Exists(_tempPath) == false)
                     Directory.CreateDirectory(_tempPath);
 
-				_dataPager = new Lazy<IVirtualPager>(() => new Win32MemoryMapPager(Path.Combine(_basePath, Constants.DatabaseFilename)));
+                if (_journalPath != tempPath && Directory.Exists(_journalPath) == false)
+                    Directory.CreateDirectory(_journalPath);
+
+				_dataPager = new Lazy<IVirtualPager>(() => new Win32MemoryMapPager(Path.Combine(_basePath, Constants.DatabaseFilename), InitialFileSize));
 			}
 
 			public override IVirtualPager DataPager
@@ -135,7 +143,7 @@ namespace Voron
 				}
 			}
 
-			public string BasePath
+			public override string BasePath
 			{
 				get { return _basePath; }
 			}
@@ -148,7 +156,7 @@ namespace Voron
 			public override IJournalWriter CreateJournalWriter(long journalNumber, long journalSize)
 			{
 				var name = JournalName(journalNumber);
-				var path = Path.Combine(_basePath, name);
+                var path = Path.Combine(_journalPath, name);
 				var result = _journals.GetOrAdd(name, _ => new Lazy<IJournalWriter>(() => new Win32FileJournalWriter(path, journalSize)));
 
 				if (result.Value.Disposed)
@@ -184,7 +192,7 @@ namespace Voron
 				if (_journals.TryRemove(name, out lazy) && lazy.IsValueCreated)
 					lazy.Value.Dispose();
 
-				var file = Path.Combine(_basePath, name);
+                var file = Path.Combine(_journalPath, name);
 				if (File.Exists(file) == false)
 					return false;
 				File.Delete(file);
@@ -200,13 +208,18 @@ namespace Voron
 				}
 				using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
 				{
-					var ptr = (byte*)header;
+				    if (fs.Length != sizeof (FileHeader))
+				        return false; // wrong file size
+
+				    var ptr = (byte*)header;
 					int remaining = sizeof(FileHeader);
 					while (remaining > 0)
 					{
 						int read;
 						if (NativeFileMethods.ReadFile(fs.SafeFileHandle, ptr, remaining, out read, null) == false)
 							throw new Win32Exception();
+					    if (read == 0)
+					        return false; // we should be reading _something_ here, if we can't, then it is an error and we assume corruption
 						ptr += read;
 						remaining -= read;
 					}
@@ -239,13 +252,13 @@ namespace Voron
 			    if (File.Exists(scratchFile)) 
                     File.Delete(scratchFile);
 
-                return new Win32MemoryMapPager(scratchFile, (NativeFileAttributes.DeleteOnClose | NativeFileAttributes.Temporary));
+                return new Win32MemoryMapPager(scratchFile, InitialFileSize, (NativeFileAttributes.DeleteOnClose | NativeFileAttributes.Temporary));
 			}
 
 			public override IVirtualPager OpenJournalPager(long journalNumber)
 			{
 				var name = JournalName(journalNumber);
-				var path = Path.Combine(_basePath, name);
+                var path = Path.Combine(_journalPath, name);
 				if (File.Exists(path) == false)
 					throw new InvalidOperationException("No such journal " + path);
 				return new Win32MemoryMapPager(path, access: NativeFileAccess.GenericRead);
@@ -256,22 +269,25 @@ namespace Voron
 		{
 			private readonly IVirtualPager _dataPager;
 
-			private Dictionary<string, IJournalWriter> _logs =
+			private readonly Dictionary<string, IJournalWriter> _logs =
 				new Dictionary<string, IJournalWriter>(StringComparer.OrdinalIgnoreCase);
 
-			private Dictionary<string, IntPtr> _headers =
+			private readonly Dictionary<string, IntPtr> _headers =
 				new Dictionary<string, IntPtr>(StringComparer.OrdinalIgnoreCase);
-
 
 			public PureMemoryStorageEnvironmentOptions()
 			{
-				//_dataPager = new Win32PureMemoryPager(); //TODO : after Win32PageFileBackedMemoryMappedPager is finished and works, change this to Win32PageFileBackedMemoryMappedPager with Guid.New as memoryName
-				_dataPager = new Win32PageFileBackedMemoryMappedPager();
+				_dataPager = new Win32PageFileBackedMemoryMappedPager("data.pager", InitialFileSize);
 			}
 
 			public override IVirtualPager DataPager
 			{
 				get { return _dataPager; }
+			}
+
+			public override string BasePath
+			{
+				get { return ":memory:"; }
 			}
 
 			public override IJournalWriter CreateJournalWriter(long journalNumber, long journalSize)
@@ -337,7 +353,7 @@ namespace Voron
 
 			public override IVirtualPager CreateScratchPager(string name)
 			{
-				return new Win32PageFileBackedMemoryMappedPager();
+				return new Win32PageFileBackedMemoryMappedPager(name, InitialFileSize);
 			}
 
 			public override IVirtualPager OpenJournalPager(long journalNumber)
@@ -358,11 +374,6 @@ namespace Voron
 		public static string JournalRecoveryName(long number)
 		{
 			return string.Format("{0:D19}.recovery", number);
-		}
-
-		public static string TempBufferName()
-		{
-			return string.Format("{0}.scratch", Guid.NewGuid());
 		}
 
 		public abstract void Dispose();

--- a/Voron/Trees/IIterator.cs
+++ b/Voron/Trees/IIterator.cs
@@ -15,7 +15,5 @@ namespace Voron.Trees
 		bool MovePrev();
 		bool Skip(int count);
 		ValueReader CreateReaderForCurrent();
-
-		IEnumerable<string> DumpValues();
 	}
 }

--- a/Voron/Trees/Page.cs
+++ b/Voron/Trees/Page.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Security.Policy;
 using System.Text;
 using Voron.Debugging;
 using Voron.Impl;
 using Voron.Impl.FileHeaders;
 using Voron.Impl.Paging;
-using Voron.Util.Conversion;
 
 namespace Voron.Trees
 {
@@ -16,16 +16,18 @@ namespace Voron.Trees
         private readonly PageHeader* _header;
 
 	    public readonly string Source;
+	    private readonly ushort _pageSize;
 
-        public int LastMatch;
+	    public int LastMatch;
         public int LastSearchPosition;
         public bool Dirty;
 
-        public Page(byte* b, string source)
+        public Page(byte* b, string source, ushort pageSize)
         {
             _base = b;
             _header = (PageHeader*)b;
 	        Source = source;
+	        _pageSize = pageSize;
         }
 
         public long PageNumber { get { return _header->PageNumber; } set { _header->PageNumber = value; } }
@@ -66,22 +68,27 @@ namespace Voron.Trees
 				return GetNode(LastSearchPosition);
 			}
 
+			var pageKey = new Slice(SliceOptions.Key);
+			if (NumberOfEntries == 1)
+			{
+				pageKey.Set(GetNode(0));
+				LastMatch = key.Compare(pageKey, cmp);
+				LastSearchPosition = LastMatch > 0 ? 1 : 0;
+				return LastSearchPosition == 0 ? GetNode(0) : null;
+			}
+
 			int low = IsLeaf ? 0 : 1;
 			int high = NumberOfEntries - 1;
 			int position = 0;
 
-			var pageKey = new Slice(SliceOptions.Key);
-			bool matched = false;
-			NodeHeader* node = null;
 			while (low <= high)
 			{
 				position = (low + high) >> 1;
 
-				node = GetNode(position);
+				var node = GetNode(position);
 				pageKey.Set(node);
 
 				LastMatch = key.Compare(pageKey, cmp);
-				matched = true;
 				if (LastMatch == 0)
 					break;
 
@@ -89,11 +96,6 @@ namespace Voron.Trees
 					low = position + 1;
 				else
 					high = position - 1;
-			}
-
-			if (matched == false)
-			{
-				LastMatch = key.Compare(pageKey, cmp);
 			}
 
 			if (LastMatch > 0) // found entry less than key
@@ -189,6 +191,18 @@ namespace Voron.Trees
 			return (byte*)node + Constants.NodeHeaderSize + key.Size;
 		}
 
+		public void ChangeImplicitRefPageNode(long implicitRefPageNumber)
+		{
+			const int implicitRefIndex = 0;
+
+			var node = GetNode(implicitRefIndex);
+
+			node->KeySize = 0;
+			node->Flags = NodeFlags.PageRef;
+			node->Version = 1;
+			node->PageNumber = implicitRefPageNumber;
+		}
+
         private NodeHeader* CreateNode(int index, Slice key, NodeFlags flags, int len, ushort previousNodeVersion)
         {
             Debug.Assert(index <= NumberOfEntries && index >= 0);
@@ -201,7 +215,7 @@ namespace Voron.Trees
             {
                 KeysOffsets[i] = KeysOffsets[i - 1];
             }
-            var nodeSize = SizeOf.NodeEntry(AbstractPager.PageMaxSpace, key, len);
+            var nodeSize = SizeOf.NodeEntry(PageMaxSpace, key, len);
             var node = AllocateNewNode(index, key, nodeSize, previousNodeVersion);
 
             if (key.Options == SliceOptions.Key)
@@ -256,7 +270,8 @@ namespace Voron.Trees
 
         private NodeHeader* AllocateNewNode(int index, Slice key, int nodeSize, ushort previousNodeVersion)
         {
-			if (previousNodeVersion + 1 > ushort.MaxValue)
+	        int newSize = previousNodeVersion + 1;
+	        if (newSize > ushort.MaxValue)
 				previousNodeVersion = 0;
 
             var newNodeOffset = (ushort)(_header->Upper - nodeSize);
@@ -280,7 +295,7 @@ namespace Voron.Trees
 
         public int SizeUsed
         {
-			get { return _header->Lower + AbstractPager.PageMaxSpace - _header->Upper; }
+			get { return _header->Lower + PageMaxSpace - _header->Upper; }
         }
 
 
@@ -308,18 +323,22 @@ namespace Voron.Trees
             // when truncating, we copy the values to a tmp page
             // this has the effect of compacting the page data and avoiding
             // internal page fragmentation
-            var copy = tx.Environment.TemporaryPage.TempPage;
-            copy.Flags = Flags;
-            for (int j = 0; j < i; j++)
-            {
-                copy.CopyNodeDataToEndOfPage(GetNode(j));
-            }
-            NativeMethods.memcpy(_base + Constants.PageHeaderSize,
-                                 copy._base + Constants.PageHeaderSize,
-								 AbstractPager.PageSize - Constants.PageHeaderSize);
+	        TemporaryPage tmp;
+	        using (tx.Environment.GetTemporaryPage(tx, out tmp))
+	        {
+		        var copy = tmp.TempPage;
+				copy.Flags = Flags;
+				for (int j = 0; j < i; j++)
+				{
+					copy.CopyNodeDataToEndOfPage(GetNode(j));
+				}
+				NativeMethods.memcpy(_base + Constants.PageHeaderSize,
+									 copy._base + Constants.PageHeaderSize,
+									 _pageSize - Constants.PageHeaderSize);
 
-            Upper = copy.Upper;
-            Lower = copy.Lower;
+				Upper = copy.Upper;
+				Lower = copy.Lower;
+	        }
 
             if (LastSearchPosition > i)
                 LastSearchPosition = i;
@@ -363,27 +382,31 @@ namespace Voron.Trees
             return true;
         }
 
-        private void Defrag(Transaction tx)
-        {
-            var tmp = tx.Environment.TemporaryPage.TempPage;
-            NativeMethods.memcpy(tmp.Base, Base, AbstractPager.PageSize);
+	    private void Defrag(Transaction tx)
+	    {
+		    TemporaryPage tmp;
+		    using (tx.Environment.GetTemporaryPage(tx, out tmp))
+		    {
+			    var tempPage = tmp.TempPage;
+			    NativeMethods.memcpy(tempPage.Base, Base, _pageSize);
 
-            var numberOfEntries = NumberOfEntries;
+			    var numberOfEntries = NumberOfEntries;
 
-            Upper = AbstractPager.PageSize;
+			    Upper = _pageSize;
 
-            for (int i = 0; i < numberOfEntries; i++)
-            {
-                var node = tmp.GetNode(i);
-                var size = node->GetNodeSize() - Constants.NodeOffsetSize;
-                size += size & 1;
-                NativeMethods.memcpy(Base + Upper - size, (byte*) node, size);
-                Upper -= (ushort)size;
-                KeysOffsets[i] = Upper;
-            }
-        }
+			    for (int i = 0; i < numberOfEntries; i++)
+			    {
+					var node = tempPage.GetNode(i);
+				    var size = node->GetNodeSize() - Constants.NodeOffsetSize;
+				    size += size & 1;
+				    NativeMethods.memcpy(Base + Upper - size, (byte*) node, size);
+				    Upper -= (ushort) size;
+				    KeysOffsets[i] = Upper;
+			    }
+		    }
+	    }
 
-        private bool HasSpaceFor(int len)
+	    private bool HasSpaceFor(int len)
         {
             return len <= SizeLeft;
         }
@@ -401,10 +424,18 @@ namespace Voron.Trees
 
         public int GetRequiredSpace(Slice key, int len)
         {
-			return SizeOf.NodeEntry(AbstractPager.PageMaxSpace, key, len) + Constants.NodeOffsetSize;
+			return SizeOf.NodeEntry(PageMaxSpace, key, len) + Constants.NodeOffsetSize;
         }
 
-        public string this[int i]
+	    public int PageMaxSpace
+	    {
+		    get
+		    {
+			    return _pageSize - Constants.PageHeaderSize;
+		    }
+	    }
+
+	    public string this[int i]
         {
             get { return new Slice(GetNode(i)).ToString(); }
         }
@@ -491,7 +522,7 @@ namespace Voron.Trees
 
         public int CalcSizeLeft()
         {
-            var sl = AbstractPager.PageMaxSpace - CalcSizeUsed();
+            var sl = PageMaxSpace - CalcSizeUsed();
             Debug.Assert(sl >= 0);
             return sl;
         }

--- a/Voron/Trees/PageIterator.cs
+++ b/Voron/Trees/PageIterator.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using Voron.Impl;
+
+namespace Voron.Trees
+{
+	public unsafe class PageIterator : IIterator
+	{
+		private readonly SliceComparer _cmp;
+		private readonly Page _page;
+		private Slice _currentKey = new Slice(SliceOptions.Key);
+
+		public PageIterator(SliceComparer cmp, Page page)
+		{
+			this._cmp = cmp;
+			this._page = page;
+		}
+
+		public void Dispose()
+		{
+			
+		}
+
+		public bool Seek(Slice key)
+		{
+			var current = _page.Search(key, _cmp);
+			if (current == null)
+				return false;
+			_currentKey.Set(current);
+			return this.ValidateCurrentKey(current, _cmp);
+		}
+
+		public NodeHeader* Current
+		{
+			get
+			{
+				if (_page.LastSearchPosition< 0  || _page.LastSearchPosition >= _page.NumberOfEntries)
+					throw new InvalidOperationException("No current page was set");
+				return _page.GetNode(_page.LastSearchPosition);
+			}
+		}
+
+
+		public Slice CurrentKey
+		{
+			get
+			{
+				if (_page.LastSearchPosition < 0 || _page.LastSearchPosition >= _page.NumberOfEntries)
+					throw new InvalidOperationException("No current page was set");
+				return _currentKey;
+			}
+		}
+		public int GetCurrentDataSize()
+		{
+			return Current->DataSize;
+		}
+
+
+		public Slice RequiredPrefix { get; set; }
+		public Slice MaxKey { get; set; }
+
+		public bool MoveNext()
+		{
+			_page.LastSearchPosition++;
+			return TrySetPosition();
+		}
+
+		public bool MovePrev()
+		{
+			_page.LastSearchPosition--;
+
+			return TrySetPosition();
+
+		}
+
+		public bool Skip(int count)
+		{
+			_page.LastSearchPosition += count;
+			
+			return TrySetPosition();
+		}
+
+		private bool TrySetPosition()
+		{
+			if (_page.LastSearchPosition < 0 || _page.LastSearchPosition >= _page.NumberOfEntries)
+				return false;
+
+			var current = _page.GetNode(_page.LastSearchPosition);
+			if (this.ValidateCurrentKey(current, _cmp) == false)
+			{
+				return false;
+			}
+			_currentKey.Set(current);
+			return true;
+		}
+
+		public ValueReader CreateReaderForCurrent()
+		{
+			var node = Current;
+			return new ValueReader((byte*)node + node->KeySize + Constants.NodeHeaderSize, node->DataSize);
+		}
+	}
+}

--- a/Voron/Trees/Tree.MultiTree.cs
+++ b/Voron/Trees/Tree.MultiTree.cs
@@ -37,10 +37,10 @@ namespace Voron.Trees
 	{
 		public bool IsMultiValueTree { get; set; }
 
-		public void MultiAdd(Transaction tx, Slice key, Slice value, ushort? version = null)
+		public void MultiAdd(Slice key, Slice value, ushort? version = null)
 		{
 			if (value == null) throw new ArgumentNullException("value");
-			int maxNodeSize = tx.DataPager.MaxNodeSize;
+			int maxNodeSize = _tx.DataPager.MaxNodeSize;
 			if (value.Size > maxNodeSize)
 				throw new ArgumentException(
 					"Cannot add a value to child tree that is over " + maxNodeSize + " bytes in size", "value");
@@ -50,37 +50,37 @@ namespace Voron.Trees
 			State.IsModified = true;
 
 			Lazy<Cursor> lazy;
-			var page = FindPageFor(tx, key, out lazy);
+			var page = FindPageFor(key, out lazy);
 			if ((page == null || page.LastMatch != 0))
 			{
-				MultiAddOnNewValue(tx, key, value, version, maxNodeSize);
+				MultiAddOnNewValue(_tx, key, value, version, maxNodeSize);
 				return;
 			}
 
-			page = tx.ModifyPage(page.PageNumber, page);
+			page = _tx.ModifyPage(page.PageNumber, page);
 
 			var item = page.GetNode(page.LastSearchPosition);
 
 			// already was turned into a multi tree, not much to do here
 			if (item->Flags == NodeFlags.MultiValuePageRef)
 			{
-				var existingTree = OpenOrCreateMultiValueTree(tx, key, item);
-				existingTree.DirectAdd(tx, value, 0, version: version);
+				var existingTree = OpenOrCreateMultiValueTree(_tx, key, item);
+				existingTree.DirectAdd(value, 0, version: version);
 				return;
 			}
 
 			byte* nestedPagePtr;
 			if (item->Flags == NodeFlags.PageRef)
 			{
-				var overFlowPage = tx.ModifyPage(item->PageNumber, null);
+				var overFlowPage = _tx.ModifyPage(item->PageNumber, null);
 				nestedPagePtr = overFlowPage.Base + Constants.PageHeaderSize;
 			}
 			else
 			{
-				nestedPagePtr = NodeHeader.DirectAccess(tx, item);
+				nestedPagePtr = NodeHeader.DirectAccess(_tx, item);
 			}
 
-			var nestedPage = new Page(nestedPagePtr, "multi tree", (ushort) NodeHeader.GetDataSize(tx, item));
+			var nestedPage = new Page(nestedPagePtr, "multi tree", (ushort)NodeHeader.GetDataSize(_tx, item));
 
 			var existingItem = nestedPage.Search(value, NativeMethods.memcmp);
 			if (nestedPage.LastMatch != 0)
@@ -98,7 +98,7 @@ namespace Voron.Trees
 				nestedPage.RemoveNode(nestedPage.LastSearchPosition);
 			}
 
-			if (nestedPage.HasSpaceFor(tx, value, 0))
+			if (nestedPage.HasSpaceFor(_tx, value, 0))
 			{
 				// we are now working on top of the modified root page, we can just modify the memory directly
 				nestedPage.AddDataNode(nestedPage.LastSearchPosition, value, 0, previousNodeRevision);
@@ -111,21 +111,21 @@ namespace Voron.Trees
 			{
 				// we can just expand the current value... no need to create a nested tree yet
 				var actualPageSize = (ushort)Math.Min(Utils.NearestPowerOfTwo(newRequiredSize), maxNodeSize);
-				ExpandMultiTreeNestedPageSize(tx, key, value, nestedPagePtr, actualPageSize, item->DataSize);
+				ExpandMultiTreeNestedPageSize(_tx, key, value, nestedPagePtr, actualPageSize, item->DataSize);
 
 				return;
 			}
 			// we now have to convert this into a tree instance, instead of just a nested page
-			var tree = Create(tx, _cmp, TreeFlags.MultiValue);
+			var tree = Create(_tx, _cmp, TreeFlags.MultiValue);
 			for (int i = 0; i < nestedPage.NumberOfEntries; i++)
 			{
 				var existingValue = nestedPage.GetNodeKey(i);
-				tree.DirectAdd(tx, existingValue, 0);
+				tree.DirectAdd(existingValue, 0);
 			}
-			tree.DirectAdd(tx, value, 0, version: version);
-			tx.AddMultiValueTree(this, key, tree);
+			tree.DirectAdd(value, 0, version: version);
+			_tx.AddMultiValueTree(this, key, tree);
 			// we need to record that we switched to tree mode here, so the next call wouldn't also try to create the tree again
-			DirectAdd(tx, key, sizeof (TreeRootHeader), NodeFlags.MultiValuePageRef);
+			DirectAdd(key, sizeof (TreeRootHeader), NodeFlags.MultiValuePageRef);
 		}
 
 		private void ExpandMultiTreeNestedPageSize(Transaction tx, Slice key, Slice value, byte* nestedPagePtr, ushort newSize, int currentSize)
@@ -136,10 +136,10 @@ namespace Voron.Trees
 			{
 				var tempPagePointer = tmp.TempPagePointer;
 				NativeMethods.memcpy(tempPagePointer, nestedPagePtr, currentSize);
-				Delete(tx, key); // release our current page
+				Delete(key); // release our current page
 				Page nestedPage = new Page(tempPagePointer, "multi tree", (ushort)currentSize);
 
-				var ptr = DirectAdd(tx, key, newSize);
+				var ptr = DirectAdd(key, newSize);
 
 				var newNestedPage = new Page(ptr, "multi tree", newSize)
 				{
@@ -172,16 +172,16 @@ namespace Voron.Trees
 				// otherwise, we would have to put this in overflow page, and that won't save us any space anyway
 
 				var tree = Create(tx, _cmp, TreeFlags.MultiValue);
-				tree.DirectAdd(tx, value, 0);
+				tree.DirectAdd(value, 0);
 				tx.AddMultiValueTree(this, key, tree);
 
-				DirectAdd(tx, key, sizeof (TreeRootHeader), NodeFlags.MultiValuePageRef);
+				DirectAdd(key, sizeof (TreeRootHeader), NodeFlags.MultiValuePageRef);
 				return;
 			}
 
 			var actualPageSize = (ushort) Math.Min(Utils.NearestPowerOfTwo(requiredPageSize), maxNodeSize);
 
-			var ptr = DirectAdd(tx, key, actualPageSize);
+			var ptr = DirectAdd(key, actualPageSize);
 
 			var nestedPage = new Page(ptr, "multi tree", actualPageSize)
 			{
@@ -196,38 +196,38 @@ namespace Voron.Trees
 			nestedPage.AddDataNode(0, value, 0, 0);
 		}
 
-		public void MultiDelete(Transaction tx, Slice key, Slice value, ushort? version = null)
+		public void MultiDelete(Slice key, Slice value, ushort? version = null)
 		{
 			State.IsModified = true;
 			Lazy<Cursor> lazy;
-			var page = FindPageFor(tx, key, out lazy);
+			var page = FindPageFor(key, out lazy);
 			if (page == null || page.LastMatch != 0)
 			{
 				return; //nothing to delete - key not found
 			}
 
-			page = tx.ModifyPage(page.PageNumber, page);
+			page = _tx.ModifyPage(page.PageNumber, page);
 
 			var item = page.GetNode(page.LastSearchPosition);
 
 			if (item->Flags == NodeFlags.MultiValuePageRef) //multi-value tree exists
 			{
-				var tree = OpenOrCreateMultiValueTree(tx, key, item);
+				var tree = OpenOrCreateMultiValueTree(_tx, key, item);
 
-				tree.Delete(tx, value, version);
+				tree.Delete(value, version);
 
 				// previously, we would convert back to a simple model if we dropped to a single entry
 				// however, it doesn't really make sense, once you got enough values to go to an actual nested 
 				// tree, you are probably going to remain that way, or be removed completely.
 				if (tree.State.EntriesCount != 0) 
 					return;
-				tx.TryRemoveMultiValueTree(this, key);
-				tx.FreePage(tree.State.RootPageNumber);
-				Delete(tx, key);
+				_tx.TryRemoveMultiValueTree(this, key);
+				_tx.FreePage(tree.State.RootPageNumber);
+				Delete(key);
 			}
 			else // we use a nested page here
 			{
-				var nestedPage = new Page(NodeHeader.DirectAccess(tx, item), "multi tree", (ushort)NodeHeader.GetDataSize(tx, item));
+				var nestedPage = new Page(NodeHeader.DirectAccess(_tx, item), "multi tree", (ushort)NodeHeader.GetDataSize(_tx, item));
 				var nestedItem = nestedPage.Search(value, NativeMethods.memcmp);
 				if (nestedItem == null) // value not found
 					return;
@@ -235,27 +235,30 @@ namespace Voron.Trees
 				byte* nestedPagePtr;
 				if (item->Flags == NodeFlags.PageRef)
 				{
-					var overFlowPage = tx.ModifyPage(item->PageNumber, null);
+					var overFlowPage = _tx.ModifyPage(item->PageNumber, null);
 					nestedPagePtr = overFlowPage.Base + Constants.PageHeaderSize;
 				}
 				else
 				{
-					nestedPagePtr = NodeHeader.DirectAccess(tx, item);
+					nestedPagePtr = NodeHeader.DirectAccess(_tx, item);
 				}
 
-				nestedPage = new Page(nestedPagePtr, "multi tree", (ushort)NodeHeader.GetDataSize(tx, item));
+				nestedPage = new Page(nestedPagePtr, "multi tree", (ushort)NodeHeader.GetDataSize(_tx, item))
+				{
+					LastSearchPosition = nestedPage.LastSearchPosition
+				};
 
 				CheckConcurrency(key, value, version, nestedItem->Version, TreeActionType.Delete);
 				nestedPage.RemoveNode(nestedPage.LastSearchPosition);
 				if (nestedPage.NumberOfEntries == 0)
-					Delete(tx, key);
+					Delete(key);
 			}
 		}
 
-		public IIterator MultiRead(Transaction tx, Slice key)
+		public IIterator MultiRead(Slice key)
 		{
 			Lazy<Cursor> lazy;
-			var page = FindPageFor(tx, key, out lazy);
+			var page = FindPageFor(key, out lazy);
 
 			if (page == null || page.LastMatch != 0)
 			{
@@ -272,17 +275,17 @@ namespace Voron.Trees
 
 			if (item->Flags == NodeFlags.MultiValuePageRef)
 			{
-				var tree = OpenOrCreateMultiValueTree(tx, key, item);
+				var tree = OpenOrCreateMultiValueTree(_tx, key, item);
 
-				return tree.Iterate(tx);
+				return tree.Iterate();
 			}
 
-			var nestedPage = new Page(NodeHeader.DirectAccess(tx, item), "multi tree", (ushort)NodeHeader.GetDataSize(tx, item));
+			var nestedPage = new Page(NodeHeader.DirectAccess(_tx, item), "multi tree", (ushort)NodeHeader.GetDataSize(_tx, item));
 				
 			return new PageIterator(_cmp, nestedPage);
 		}
 
-		internal Tree OpenOrCreateMultiValueTree(Transaction tx, Slice key, NodeHeader* item)
+		private Tree OpenOrCreateMultiValueTree(Transaction tx, Slice key, NodeHeader* item)
 		{
 			Tree tree;
 			if (tx.TryGetMultiValueTree(this, key, out tree))
@@ -297,24 +300,6 @@ namespace Voron.Trees
 
 			tx.AddMultiValueTree(this, key, tree);
 			return tree;
-		}
-
-		public bool SetAsMultiValueTreeRef(Transaction tx, Slice key)
-		{
-			Lazy<Cursor> lazy;
-			var foundPage = FindPageFor(tx, key, out lazy);
-			var page = tx.ModifyPage(foundPage.PageNumber, foundPage);
-
-			if (page.LastMatch != 0)
-				return false; // not there
-
-			var nodeHeader = page.GetNode(page.LastSearchPosition);
-			if (nodeHeader->Flags == NodeFlags.MultiValuePageRef)
-				return false;
-			if (nodeHeader->Flags != NodeFlags.Data)
-				throw new InvalidOperationException("Only data nodes can be set to MultiValuePageRef");
-			nodeHeader->Flags = NodeFlags.MultiValuePageRef;
-			return true;
 		}
 
 		private bool TryOverwriteDataOrMultiValuePageRefNode(NodeHeader* updatedNode, Slice key, int len,

--- a/Voron/Trees/Tree.MultiTree.cs
+++ b/Voron/Trees/Tree.MultiTree.cs
@@ -1,0 +1,356 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="Tree.MultiTree.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Diagnostics;
+using System.IO;
+using Voron.Impl;
+using Voron.Impl.FileHeaders;
+using Voron.Impl.Paging;
+using Voron.Util;
+
+namespace Voron.Trees
+{
+	/* Multi tree behavior
+	 * -------------------
+	 * A multi tree is a tree that is used only with MultiRead, MultiAdd, MultiDelete
+	 * The common use case is a secondary index that allows duplicates. 
+	 * 
+	 * The API exposed goes like this:
+	 * 
+	 * MultiAdd("key", "val1"), MultiAdd("key", "val2"), MultiAdd("key", "val3") 
+	 * 
+	 * And then you can read it back with MultiRead("key") : IIterator
+	 * 
+	 * When deleting, you delete one value at a time: MultiDelete("key", "val1")
+	 * 
+	 * The actual values are stored as keys in a separate tree per key. In order to optimize
+	 * space usage, multi trees work in the following fashion.
+	 * 
+	 * If the totale size of the values per key is less than NodeMaxSize, we store them as an embedded
+	 * page inside the owning tree. If then are more than the node max size, we create a separate tree
+	 * for them and then only store the tree root infromation.
+	 */
+	public unsafe partial class Tree
+	{
+		public bool IsMultiValueTree { get; set; }
+
+		public void MultiAdd(Transaction tx, Slice key, Slice value, ushort? version = null)
+		{
+			if (value == null) throw new ArgumentNullException("value");
+			int maxNodeSize = tx.DataPager.MaxNodeSize;
+			if (value.Size > maxNodeSize)
+				throw new ArgumentException(
+					"Cannot add a value to child tree that is over " + maxNodeSize + " bytes in size", "value");
+			if (value.Size == 0)
+				throw new ArgumentException("Cannot add empty value to child tree");
+
+			State.IsModified = true;
+
+			Lazy<Cursor> lazy;
+			var page = FindPageFor(tx, key, out lazy);
+			if ((page == null || page.LastMatch != 0))
+			{
+				MultiAddOnNewValue(tx, key, value, version, maxNodeSize);
+				return;
+			}
+
+			page = tx.ModifyPage(page.PageNumber, page);
+
+			var item = page.GetNode(page.LastSearchPosition);
+
+			// already was turned into a multi tree, not much to do here
+			if (item->Flags == NodeFlags.MultiValuePageRef)
+			{
+				var existingTree = OpenOrCreateMultiValueTree(tx, key, item);
+				existingTree.DirectAdd(tx, value, 0, version: version);
+				return;
+			}
+
+			byte* nestedPagePtr;
+			if (item->Flags == NodeFlags.PageRef)
+			{
+				var overFlowPage = tx.ModifyPage(item->PageNumber, null);
+				nestedPagePtr = overFlowPage.Base + Constants.PageHeaderSize;
+			}
+			else
+			{
+				nestedPagePtr = NodeHeader.DirectAccess(tx, item);
+			}
+
+			var nestedPage = new Page(nestedPagePtr, "multi tree", (ushort) NodeHeader.GetDataSize(tx, item));
+
+			var existingItem = nestedPage.Search(value, NativeMethods.memcmp);
+			if (nestedPage.LastMatch != 0)
+				existingItem = null;// not an actual match, just greater than
+
+			ushort previousNodeRevision = existingItem != null ?  existingItem->Version : (ushort)0;
+			CheckConcurrency(key, value, version, previousNodeRevision, TreeActionType.Add);
+			
+			if (existingItem != null)
+			{
+				// maybe same value added twice?
+				var tmpKey = new Slice(item);
+				if (tmpKey.Compare(value, _cmp) == 0)
+					return; // already there, turning into a no-op
+				nestedPage.RemoveNode(nestedPage.LastSearchPosition);
+			}
+
+			if (nestedPage.HasSpaceFor(tx, value, 0))
+			{
+				// we are now working on top of the modified root page, we can just modify the memory directly
+				nestedPage.AddDataNode(nestedPage.LastSearchPosition, value, 0, previousNodeRevision);
+				return;
+			}
+
+			int pageSize = nestedPage.CalcSizeUsed() + Constants.PageHeaderSize;
+			var newRequiredSize = pageSize + nestedPage.GetRequiredSpace(value, 0);
+			if (newRequiredSize <= maxNodeSize)
+			{
+				// we can just expand the current value... no need to create a nested tree yet
+				var actualPageSize = (ushort)Math.Min(Utils.NearestPowerOfTwo(newRequiredSize), maxNodeSize);
+				ExpandMultiTreeNestedPageSize(tx, key, value, nestedPagePtr, actualPageSize, item->DataSize);
+
+				return;
+			}
+			// we now have to convert this into a tree instance, instead of just a nested page
+			var tree = Create(tx, _cmp, TreeFlags.MultiValue);
+			for (int i = 0; i < nestedPage.NumberOfEntries; i++)
+			{
+				var existingValue = nestedPage.GetNodeKey(i);
+				tree.DirectAdd(tx, existingValue, 0);
+			}
+			tree.DirectAdd(tx, value, 0, version: version);
+			tx.AddMultiValueTree(this, key, tree);
+			// we need to record that we switched to tree mode here, so the next call wouldn't also try to create the tree again
+			DirectAdd(tx, key, sizeof (TreeRootHeader), NodeFlags.MultiValuePageRef);
+		}
+
+		private void ExpandMultiTreeNestedPageSize(Transaction tx, Slice key, Slice value, byte* nestedPagePtr, ushort newSize, int currentSize)
+		{
+			Debug.Assert(newSize > currentSize);
+			TemporaryPage tmp;
+			using (tx.Environment.GetTemporaryPage(tx, out tmp))
+			{
+				var tempPagePointer = tmp.TempPagePointer;
+				NativeMethods.memcpy(tempPagePointer, nestedPagePtr, currentSize);
+				Delete(tx, key); // release our current page
+				Page nestedPage = new Page(tempPagePointer, "multi tree", (ushort)currentSize);
+
+				var ptr = DirectAdd(tx, key, newSize);
+
+				var newNestedPage = new Page(ptr, "multi tree", newSize)
+				{
+					Lower = (ushort)Constants.PageHeaderSize,
+					Upper = newSize,
+					Flags = PageFlags.Leaf,
+					PageNumber = -1L // mark as invalid page number
+				};
+
+				Slice nodeKey = new Slice(SliceOptions.Key);
+				for (int i = 0; i < nestedPage.NumberOfEntries; i++)
+				{
+					var nodeHeader = nestedPage.GetNode(i);
+					nodeKey.Set(nodeHeader);
+					newNestedPage.AddDataNode(i, nodeKey, 0,
+						(ushort)(nodeHeader->Version - 1)); // we dec by one because AdddataNode will inc by one, and we don't want to change those values
+				}
+
+				newNestedPage.Search(value, _cmp);
+				newNestedPage.AddDataNode(newNestedPage.LastSearchPosition, value, 0, 0);
+			}
+		}
+
+		private void MultiAddOnNewValue(Transaction tx, Slice key, Slice value, ushort? version, int maxNodeSize)
+		{
+			var requiredPageSize = Constants.PageHeaderSize + SizeOf.LeafEntry(-1, value, 0) + Constants.NodeOffsetSize;
+			if (requiredPageSize > maxNodeSize)
+			{
+				// no choice, very big value, we might as well just put it in its own tree from the get go...
+				// otherwise, we would have to put this in overflow page, and that won't save us any space anyway
+
+				var tree = Create(tx, _cmp, TreeFlags.MultiValue);
+				tree.DirectAdd(tx, value, 0);
+				tx.AddMultiValueTree(this, key, tree);
+
+				DirectAdd(tx, key, sizeof (TreeRootHeader), NodeFlags.MultiValuePageRef);
+				return;
+			}
+
+			var actualPageSize = (ushort) Math.Min(Utils.NearestPowerOfTwo(requiredPageSize), maxNodeSize);
+
+			var ptr = DirectAdd(tx, key, actualPageSize);
+
+			var nestedPage = new Page(ptr, "multi tree", actualPageSize)
+			{
+				PageNumber = -1L,// hint that this is an inner page
+				Lower = (ushort) Constants.PageHeaderSize,
+				Upper = actualPageSize,
+				Flags = PageFlags.Leaf,
+			};
+
+			CheckConcurrency(key, value, version, 0, TreeActionType.Add);
+
+			nestedPage.AddDataNode(0, value, 0, 0);
+		}
+
+		public void MultiDelete(Transaction tx, Slice key, Slice value, ushort? version = null)
+		{
+			State.IsModified = true;
+			Lazy<Cursor> lazy;
+			var page = FindPageFor(tx, key, out lazy);
+			if (page == null || page.LastMatch != 0)
+			{
+				return; //nothing to delete - key not found
+			}
+
+			page = tx.ModifyPage(page.PageNumber, page);
+
+			var item = page.GetNode(page.LastSearchPosition);
+
+			if (item->Flags == NodeFlags.MultiValuePageRef) //multi-value tree exists
+			{
+				var tree = OpenOrCreateMultiValueTree(tx, key, item);
+
+				tree.Delete(tx, value, version);
+
+				// previously, we would convert back to a simple model if we dropped to a single entry
+				// however, it doesn't really make sense, once you got enough values to go to an actual nested 
+				// tree, you are probably going to remain that way, or be removed completely.
+				if (tree.State.EntriesCount != 0) 
+					return;
+				tx.TryRemoveMultiValueTree(this, key);
+				tx.FreePage(tree.State.RootPageNumber);
+				Delete(tx, key);
+			}
+			else // we use a nested page here
+			{
+				var nestedPage = new Page(NodeHeader.DirectAccess(tx, item), "multi tree", (ushort)NodeHeader.GetDataSize(tx, item));
+				var nestedItem = nestedPage.Search(value, NativeMethods.memcmp);
+				if (nestedItem == null) // value not found
+					return;
+
+				byte* nestedPagePtr;
+				if (item->Flags == NodeFlags.PageRef)
+				{
+					var overFlowPage = tx.ModifyPage(item->PageNumber, null);
+					nestedPagePtr = overFlowPage.Base + Constants.PageHeaderSize;
+				}
+				else
+				{
+					nestedPagePtr = NodeHeader.DirectAccess(tx, item);
+				}
+
+				nestedPage = new Page(nestedPagePtr, "multi tree", (ushort)NodeHeader.GetDataSize(tx, item));
+
+				CheckConcurrency(key, value, version, nestedItem->Version, TreeActionType.Delete);
+				nestedPage.RemoveNode(nestedPage.LastSearchPosition);
+				if (nestedPage.NumberOfEntries == 0)
+					Delete(tx, key);
+			}
+		}
+
+		public IIterator MultiRead(Transaction tx, Slice key)
+		{
+			Lazy<Cursor> lazy;
+			var page = FindPageFor(tx, key, out lazy);
+
+			if (page == null || page.LastMatch != 0)
+			{
+				return new EmptyIterator();
+			}
+
+			var item = page.Search(key, _cmp);
+
+			var fetchedNodeKey = new Slice(item);
+			if (fetchedNodeKey.Compare(key, _cmp) != 0)
+			{
+				throw new InvalidDataException("Was unable to retrieve the correct node. Data corruption possible");
+			}
+
+			if (item->Flags == NodeFlags.MultiValuePageRef)
+			{
+				var tree = OpenOrCreateMultiValueTree(tx, key, item);
+
+				return tree.Iterate(tx);
+			}
+
+			var nestedPage = new Page(NodeHeader.DirectAccess(tx, item), "multi tree", (ushort)NodeHeader.GetDataSize(tx, item));
+				
+			return new PageIterator(_cmp, nestedPage);
+		}
+
+		internal Tree OpenOrCreateMultiValueTree(Transaction tx, Slice key, NodeHeader* item)
+		{
+			Tree tree;
+			if (tx.TryGetMultiValueTree(this, key, out tree))
+				return tree;
+
+			var childTreeHeader =
+				(TreeRootHeader*)((byte*)item + item->KeySize + Constants.NodeHeaderSize);
+			Debug.Assert(childTreeHeader->RootPageNumber < tx.State.NextPageNumber);
+			tree = childTreeHeader != null ?
+				Open(tx, _cmp, childTreeHeader) :
+				Create(tx, _cmp);
+
+			tx.AddMultiValueTree(this, key, tree);
+			return tree;
+		}
+
+		public bool SetAsMultiValueTreeRef(Transaction tx, Slice key)
+		{
+			Lazy<Cursor> lazy;
+			var foundPage = FindPageFor(tx, key, out lazy);
+			var page = tx.ModifyPage(foundPage.PageNumber, foundPage);
+
+			if (page.LastMatch != 0)
+				return false; // not there
+
+			var nodeHeader = page.GetNode(page.LastSearchPosition);
+			if (nodeHeader->Flags == NodeFlags.MultiValuePageRef)
+				return false;
+			if (nodeHeader->Flags != NodeFlags.Data)
+				throw new InvalidOperationException("Only data nodes can be set to MultiValuePageRef");
+			nodeHeader->Flags = NodeFlags.MultiValuePageRef;
+			return true;
+		}
+
+		private bool TryOverwriteDataOrMultiValuePageRefNode(NodeHeader* updatedNode, Slice key, int len,
+														NodeFlags requestedNodeType, ushort? version,
+														out byte* pos)
+		{
+			switch (requestedNodeType)
+			{
+				case NodeFlags.Data:
+				case NodeFlags.MultiValuePageRef:
+					{
+						if (updatedNode->DataSize == len &&
+							(updatedNode->Flags == NodeFlags.Data || updatedNode->Flags == NodeFlags.MultiValuePageRef))
+						{
+							CheckConcurrency(key, version, updatedNode->Version, TreeActionType.Add);
+
+							if (updatedNode->Version == ushort.MaxValue)
+								updatedNode->Version = 0;
+							updatedNode->Version++;
+
+							updatedNode->Flags = requestedNodeType;
+
+							{
+								pos = (byte*)updatedNode + Constants.NodeHeaderSize + key.Size;
+								return true;
+							}
+						}
+						break;
+					}
+				case NodeFlags.PageRef:
+					throw new InvalidOperationException("We never add PageRef explicitly");
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+			pos = null;
+			return false;
+		}
+	}
+}

--- a/Voron/Trees/Tree.cs
+++ b/Voron/Trees/Tree.cs
@@ -22,23 +22,27 @@ namespace Voron.Trees
 			get { return _state; }
 		}
 
+		private readonly Transaction _tx;
+
 		private readonly SliceComparer _cmp;
 
-		private Tree(SliceComparer cmp, long root)
+		private Tree(Transaction tx, SliceComparer cmp, long root)
 		{
+			_tx = tx;
 			_cmp = cmp;
 			_state.RootPageNumber = root;
 		}
 
-		private Tree(SliceComparer cmp, TreeMutableState state)
+		private Tree(Transaction tx, SliceComparer cmp, TreeMutableState state)
 		{
+			_tx = tx;
 			_cmp = cmp;
 			_state = state;
 		}
 
 		public static Tree Open(Transaction tx, SliceComparer cmp, TreeRootHeader* header)
 		{
-			return new Tree(cmp, header->RootPageNumber)
+			return new Tree(tx, cmp, header->RootPageNumber)
 			{
 				_state =
 				{
@@ -57,7 +61,7 @@ namespace Voron.Trees
 		public static Tree Create(Transaction tx, SliceComparer cmp, TreeFlags flags = TreeFlags.None)
 		{
 			var newRootPage = NewPage(tx, PageFlags.Leaf, 1);
-			var tree = new Tree(cmp, newRootPage.PageNumber)
+			var tree = new Tree(tx, cmp, newRootPage.PageNumber)
 			{
 				_state =
 				{
@@ -71,38 +75,39 @@ namespace Voron.Trees
 			return tree;
 		}
 
-		public void Add(Transaction tx, Slice key, Stream value, ushort? version = null)
+		public void Add(Slice key, Stream value, ushort? version = null)
 		{
 		    if (value == null) throw new ArgumentNullException("value");
 		    if (value.Length > int.MaxValue)
 		        throw new ArgumentException("Cannot add a value that is over 2GB in size", "value");
 
 			State.IsModified = true;
-			var pos = DirectAdd(tx, key, (int)value.Length, version: version);
+			var pos = DirectAdd(key, (int)value.Length, version: version);
 		    
-		    CopyStreamToPointer(tx, value, pos);
+		    CopyStreamToPointer(_tx, value, pos);
 		}
 
-		public long Increment(Transaction tx, Slice key, long delta, ushort? version = null)
+		public long Increment(Slice key, long delta, ushort? version = null)
 		{
 			long currentValue = 0;
 
-			var read = Read(tx, key);
-			if (read != null)
-				currentValue = read.Reader.ReadLittleEndianInt64();
+			var read = Read(key);
+		    if (read != null)
+		        currentValue = *(long*)read.Reader.Base;
 
 			var value = currentValue + delta;
-			Add(tx, key, BitConverter.GetBytes(value), version);
+            var result = (long*)DirectAdd(key, sizeof(long), version: version);
+		    *result = value;
 
 			return value;
 		}
 
-		public void Add(Transaction tx, Slice key, byte[] value, ushort? version = null)
+		public void Add(Slice key, byte[] value, ushort? version = null)
 		{
 			if (value == null) throw new ArgumentNullException("value");
 
 			State.IsModified = true;
-			var pos = DirectAdd(tx, key, value.Length, version: version);
+			var pos = DirectAdd(key, value.Length, version: version);
 
 			fixed (byte* src = value)
 			{
@@ -110,12 +115,12 @@ namespace Voron.Trees
 			}
 		}
 
-		public void Add(Transaction tx, Slice key, Slice value, ushort? version = null)
+		public void Add(Slice key, Slice value, ushort? version = null)
 		{
 			if (value == null) throw new ArgumentNullException("value");
 
 			State.IsModified = true;
-			var pos = DirectAdd(tx, key, value.Size, version: version);
+			var pos = DirectAdd(key, value.Size, version: version);
 
 			value.CopyTo(pos);
 		}
@@ -138,21 +143,21 @@ namespace Voron.Trees
 			}
 		}
 
-		internal byte* DirectAdd(Transaction tx, Slice key, int len, NodeFlags nodeType = NodeFlags.Data, ushort? version = null)
+		internal byte* DirectAdd(Slice key, int len, NodeFlags nodeType = NodeFlags.Data, ushort? version = null)
 		{
 			Debug.Assert(nodeType == NodeFlags.Data || nodeType == NodeFlags.MultiValuePageRef);
 
-			if (tx.Flags == (TransactionFlags.ReadWrite) == false)
+			if (_tx.Flags == (TransactionFlags.ReadWrite) == false)
 				throw new ArgumentException("Cannot add a value in a read only transaction");
 
-			if (key.Size > tx.DataPager.MaxNodeSize)
+			if (key.Size > _tx.DataPager.MaxNodeSize)
 				throw new ArgumentException(
-					"Key size is too big, must be at most " + tx.DataPager.MaxNodeSize + " bytes, but was " + key.Size, "key");
+					"Key size is too big, must be at most " + _tx.DataPager.MaxNodeSize + " bytes, but was " + key.Size, "key");
 
 			Lazy<Cursor> lazy;
-			var foundPage = FindPageFor(tx, key, out lazy);
+			var foundPage = FindPageFor(key, out lazy);
 
-			var page = tx.ModifyPage(foundPage.PageNumber, foundPage);
+			var page = _tx.ModifyPage(foundPage.PageNumber, foundPage);
 
 			ushort nodeVersion = 0;
 			bool? shouldGoToOverflowPage = null;
@@ -162,7 +167,7 @@ namespace Voron.Trees
 
 				Debug.Assert(node->KeySize == key.Size && new Slice(node).Equals(key));
 
-				shouldGoToOverflowPage = tx.DataPager.ShouldGoToOverflowPage(len);
+				shouldGoToOverflowPage = _tx.DataPager.ShouldGoToOverflowPage(len);
 
 				byte* pos;
 				if (shouldGoToOverflowPage == false)
@@ -174,11 +179,11 @@ namespace Voron.Trees
 				else
 				{
 					// optimization for PageRef - try to overwrite existing overflows
-					if (TryOverwriteOverflowPages(tx, State, node, key, len, version, out pos))
+					if (TryOverwriteOverflowPages(State, node, key, len, version, out pos))
 						return pos;
 				}
 
-				RemoveLeafNode(tx, page, out nodeVersion);
+				RemoveLeafNode(page, out nodeVersion);
 			}
 			else // new item should be recorded
 			{
@@ -190,23 +195,23 @@ namespace Voron.Trees
 			var lastSearchPosition = page.LastSearchPosition; // searching for overflow pages might change this
 			byte* overFlowPos = null;
 			var pageNumber = -1L;
-			if (shouldGoToOverflowPage ?? tx.DataPager.ShouldGoToOverflowPage(len))
+			if (shouldGoToOverflowPage ?? _tx.DataPager.ShouldGoToOverflowPage(len))
 			{
-				pageNumber = WriteToOverflowPages(tx, State, len, out overFlowPos);
+				pageNumber = WriteToOverflowPages(State, len, out overFlowPos);
 				len = -1;
 				nodeType = NodeFlags.PageRef;
 			}
 
 			byte* dataPos;
-			if (page.HasSpaceFor(tx, key, len) == false)
+			if (page.HasSpaceFor(_tx, key, len) == false)
 			{
 			    var cursor = lazy.Value;
 			    cursor.Update(cursor.Pages.First, page);
-			    
-			    var pageSplitter = new PageSplitter(tx, this, _cmp, key, len, pageNumber, nodeType, nodeVersion, cursor, State);
+
+				var pageSplitter = new PageSplitter(_tx, this, _cmp, key, len, pageNumber, nodeType, nodeVersion, cursor, State);
 			    dataPos = pageSplitter.Execute();
 
-			    DebugValidateTree(tx, State.RootPageNumber);
+				DebugValidateTree(State.RootPageNumber);
 			}
 			else
 			{
@@ -224,18 +229,17 @@ namespace Voron.Trees
 					default:
 						throw new NotSupportedException("Unknown node type for direct add operation: " + nodeType);
 				}
-				page.DebugValidate(tx, _cmp, State.RootPageNumber);
+				page.DebugValidate(_tx, _cmp, State.RootPageNumber);
 			}
 			if (overFlowPos != null)
 				return overFlowPos;
 			return dataPos;
 		}
 
-
-		private long WriteToOverflowPages(Transaction tx, TreeMutableState txInfo, int overflowSize, out byte* dataPos)
+		private long WriteToOverflowPages(TreeMutableState txInfo, int overflowSize, out byte* dataPos)
 		{
-			var numberOfPages = tx.DataPager.GetNumberOfOverflowPages(overflowSize);
-			var overflowPageStart = tx.AllocatePage(numberOfPages);
+			var numberOfPages = _tx.DataPager.GetNumberOfOverflowPages(overflowSize);
+			var overflowPageStart = _tx.AllocatePage(numberOfPages);
 			overflowPageStart.Flags = PageFlags.Overflow;
 			overflowPageStart.OverflowSize = overflowSize;
 			dataPos = overflowPageStart.Base + Constants.PageHeaderSize;
@@ -244,17 +248,17 @@ namespace Voron.Trees
 			return overflowPageStart.PageNumber;
 		}
 
-		private void RemoveLeafNode(Transaction tx, Page page, out ushort nodeVersion)
+		private void RemoveLeafNode(Page page, out ushort nodeVersion)
 		{
 			var node = page.GetNode(page.LastSearchPosition);
 			nodeVersion = node->Version;
 			if (node->Flags == (NodeFlags.PageRef)) // this is an overflow pointer
 			{
-				var overflowPage = tx.GetReadOnlyPage(node->PageNumber);
-				var numberOfPages = tx.DataPager.GetNumberOfOverflowPages(overflowPage.OverflowSize);
+				var overflowPage = _tx.GetReadOnlyPage(node->PageNumber);
+				var numberOfPages = _tx.DataPager.GetNumberOfOverflowPages(overflowPage.OverflowSize);
 				for (int i = 0; i < numberOfPages; i++)
 				{
-					tx.FreePage(overflowPage.PageNumber + i);
+					_tx.FreePage(overflowPage.PageNumber + i);
 				}
 
 				State.OverflowPages -= numberOfPages;
@@ -264,11 +268,11 @@ namespace Voron.Trees
 		}
 
 		[Conditional("VALIDATE")]
-		public void DebugValidateTree(Transaction tx, long rootPageNumber)
+		public void DebugValidateTree(long rootPageNumber)
 		{
 			var pages = new HashSet<long>();
 			var stack = new Stack<Page>();
-			var root = tx.GetReadOnlyPage(rootPageNumber);
+			var root = _tx.GetReadOnlyPage(rootPageNumber);
 			stack.Push(root);
 			pages.Add(rootPageNumber);
 			while (stack.Count > 0)
@@ -276,11 +280,11 @@ namespace Voron.Trees
 				var p = stack.Pop();
 				if (p.NumberOfEntries == 0 && p != root)
 				{
-					DebugStuff.RenderAndShow(tx, rootPageNumber, 1);
+					DebugStuff.RenderAndShow(_tx, rootPageNumber, 1);
 					throw new InvalidOperationException("The page " + p.PageNumber + " is empty");
 
 				}
-				p.DebugValidate(tx, _cmp, rootPageNumber);
+				p.DebugValidate(_tx, _cmp, rootPageNumber);
 				if (p.IsBranch == false)
 					continue;
 				for (int i = 0; i < p.NumberOfEntries; i++)
@@ -288,29 +292,29 @@ namespace Voron.Trees
 					var page = p.GetNode(i)->PageNumber;
 					if (pages.Add(page) == false)
 					{
-						DebugStuff.RenderAndShow(tx, rootPageNumber, 1);
+						DebugStuff.RenderAndShow(_tx, rootPageNumber, 1);
 						throw new InvalidOperationException("The page " + page + " already appeared in the tree!");
 					}
-					stack.Push(tx.GetReadOnlyPage(page));
+					stack.Push(_tx.GetReadOnlyPage(page));
 				}
 			}
 		}
 
-		public Page FindPageFor(Transaction tx, Slice key, out Lazy<Cursor> cursor)
+		internal Page FindPageFor(Slice key, out Lazy<Cursor> cursor)
 		{
 			Page p;
 
-		    if (TryUseRecentTransactionPage(tx, key, out cursor, out p))
+			if (TryUseRecentTransactionPage(key, out cursor, out p))
 		    {
 		        return p;
 		    }
 
-			return SearchForPage(tx, key, ref cursor);
+			return SearchForPage(key, ref cursor);
 		}
 
-	    private Page SearchForPage(Transaction tx, Slice key, ref Lazy<Cursor> cursor)
+	    private Page SearchForPage(Slice key, ref Lazy<Cursor> cursor)
 	    {
-	        var p = tx.GetReadOnlyPage(State.RootPageNumber);
+			var p = _tx.GetReadOnlyPage(State.RootPageNumber);
 	        var c = new Cursor();
 	        c.Push(p);
 
@@ -355,7 +359,7 @@ namespace Voron.Trees
 	            }
 
 	            var node = p.GetNode(nodePos);
-	            p = tx.GetReadOnlyPage(node->PageNumber);
+				p = _tx.GetReadOnlyPage(node->PageNumber);
 	            Debug.Assert(node->PageNumber == p.PageNumber,
 	                string.Format("Requested Page: #{0}. Got Page: #{1}", node->PageNumber, p.PageNumber));
 
@@ -367,13 +371,13 @@ namespace Voron.Trees
 
 	        p.Search(key, _cmp); // will set the LastSearchPosition
 
-	        AddToRecentlyFoundPages(tx, c, p, leftmostPage, rightmostPage);
+	        AddToRecentlyFoundPages(c, p, leftmostPage, rightmostPage);
 
 	        cursor = new Lazy<Cursor>(() => c);
 	        return p;
 	    }
 
-	    private void AddToRecentlyFoundPages(Transaction tx, Cursor c, Page p, bool? leftmostPage, bool? rightmostPage)
+	    private void AddToRecentlyFoundPages(Cursor c, Page p, bool? leftmostPage, bool? rightmostPage)
 	    {
 	        var foundPage = new RecentlyFoundPages.FoundPage(c.Pages.Count)
 	        {
@@ -389,15 +393,15 @@ namespace Voron.Trees
 	            cur = cur.Next;
 	        }
 
-	        tx.AddRecentlyFoundPage(this, foundPage);
+			_tx.AddRecentlyFoundPage(this, foundPage);
 	    }
 
-	    private bool TryUseRecentTransactionPage(Transaction tx, Slice key, out Lazy<Cursor> cursor, out Page page)
+	    private bool TryUseRecentTransactionPage(Slice key, out Lazy<Cursor> cursor, out Page page)
 		{
 			page = null;
 			cursor = null;
 
-			var recentPages = tx.GetRecentlyFoundPages(this);
+			var recentPages = _tx.GetRecentlyFoundPages(this);
 
 			if (recentPages == null)
 				return false;
@@ -408,7 +412,7 @@ namespace Voron.Trees
 				return false;
 
 			var lastFoundPageNumber = foundPage.Number;
-			page = tx.GetReadOnlyPage(lastFoundPageNumber);
+			page = _tx.GetReadOnlyPage(lastFoundPageNumber);
 
 			if (page.IsLeaf == false)
 				throw new DataException("Index points to a non leaf page");
@@ -426,7 +430,7 @@ namespace Voron.Trees
 						c.Push(pageCopy);
 					else
 					{
-						var cursorPage = tx.GetReadOnlyPage(p);
+						var cursorPage = _tx.GetReadOnlyPage(p);
 						if (key.Options == SliceOptions.BeforeAllKeys)
 						{
 							cursorPage.LastSearchPosition = 0;
@@ -461,59 +465,59 @@ namespace Voron.Trees
 			return page;
 		}
 
-		public void Delete(Transaction tx, Slice key, ushort? version = null)
+		public void Delete(Slice key, ushort? version = null)
 		{
-			if (tx.Flags == (TransactionFlags.ReadWrite) == false)
+			if (_tx.Flags == (TransactionFlags.ReadWrite) == false)
 				throw new ArgumentException("Cannot delete a value in a read only transaction");
 
 			State.IsModified = true;
 			Lazy<Cursor> lazy;
-			var page = FindPageFor(tx, key, out lazy);
+			var page = FindPageFor(key, out lazy);
 
 			page.NodePositionFor(key, _cmp);
 			if (page.LastMatch != 0)
 				return; // not an exact match, can't delete
 
-			page = tx.ModifyPage(page.PageNumber, page);
+			page = _tx.ModifyPage(page.PageNumber, page);
 
 			State.EntriesCount--;
 			ushort nodeVersion;
-			RemoveLeafNode(tx, page, out nodeVersion);
+			RemoveLeafNode(page, out nodeVersion);
 
 			CheckConcurrency(key, version, nodeVersion, TreeActionType.Delete);
 
-			var treeRebalancer = new TreeRebalancer(tx, this);
+			var treeRebalancer = new TreeRebalancer(_tx, this);
 			var changedPage = page;
 			while (changedPage != null)
 			{
 				changedPage = treeRebalancer.Execute(lazy.Value, changedPage);
 			}
 
-			page.DebugValidate(tx, _cmp, State.RootPageNumber);
+			page.DebugValidate(_tx, _cmp, State.RootPageNumber);
 		}
 
-		public TreeIterator Iterate(Transaction tx, WriteBatch writeBatch = null)
+		public TreeIterator Iterate(WriteBatch writeBatch = null)
 		{
-			return new TreeIterator(this, tx, _cmp);
+			return new TreeIterator(this, _tx, _cmp);
 		}
 
-		public ReadResult Read(Transaction tx, Slice key)
+		public ReadResult Read(Slice key)
 		{
 			Lazy<Cursor> lazy;
-			var p = FindPageFor(tx, key, out lazy);
+			var p = FindPageFor(key, out lazy);
 
             if (p.LastMatch != 0)
 		        return null;
 
 		    var node = p.GetNode(p.LastSearchPosition);
 
-		    return new ReadResult(NodeHeader.Reader(tx, node), node->Version);
+			return new ReadResult(NodeHeader.Reader(_tx, node), node->Version);
 		}
 
-		public int GetDataSize(Transaction tx, Slice key)
+		public int GetDataSize(Slice key)
 		{
 			Lazy<Cursor> lazy;
-			var p = FindPageFor(tx, key, out lazy);
+			var p = FindPageFor(key, out lazy);
 			var node = p.Search(key, _cmp);
 
 			if (node == null || new Slice(node).Compare(key, _cmp) != 0)
@@ -522,10 +526,10 @@ namespace Voron.Trees
 			return node->DataSize;
 		}
 
-		public ushort ReadVersion(Transaction tx, Slice key)
+		public ushort ReadVersion(Slice key)
 		{
 			Lazy<Cursor> lazy;
-			var p = FindPageFor(tx, key, out lazy);
+			var p = FindPageFor(key, out lazy);
 			var node = p.Search(key, _cmp);
 
 			if (node == null || new Slice(node).Compare(key, _cmp) != 0)
@@ -534,11 +538,10 @@ namespace Voron.Trees
 			return node->Version;
 		}
 
-
-		internal byte* DirectRead(Transaction tx, Slice key)
+		internal byte* DirectRead(Slice key)
 		{
 			Lazy<Cursor> lazy;
-			var p = FindPageFor(tx, key, out lazy);
+			var p = FindPageFor(key, out lazy);
 			var node = p.Search(key, _cmp);
 
 			if (node == null)
@@ -551,23 +554,18 @@ namespace Voron.Trees
 
 			if (node->Flags == (NodeFlags.PageRef))
 			{
-				var overFlowPage = tx.GetReadOnlyPage(node->PageNumber);
+				var overFlowPage = _tx.GetReadOnlyPage(node->PageNumber);
 				return overFlowPage.Base + Constants.PageHeaderSize;
 			}
 
 			return (byte*) node + node->KeySize + Constants.NodeHeaderSize;
 		}
 
-		internal void SetState(TreeMutableState state)
-		{
-			_state = state;
-		}
-
-		public List<long> AllPages(Transaction tx)
+		public List<long> AllPages()
 		{
 			var results = new List<long>();
 			var stack = new Stack<Page>();
-			var root = tx.GetReadOnlyPage(State.RootPageNumber);
+			var root = _tx.GetReadOnlyPage(State.RootPageNumber);
 			stack.Push(root);
 			while (stack.Count > 0)
 			{
@@ -579,13 +577,13 @@ namespace Voron.Trees
 					var pageNumber = node->PageNumber;
 					if (p.IsBranch)
 					{
-						stack.Push(tx.GetReadOnlyPage(pageNumber));
+						stack.Push(_tx.GetReadOnlyPage(pageNumber));
 					}
 					else if (node->Flags == NodeFlags.PageRef)
 					{
 						// This is an overflow page
-						var overflowPage = tx.GetReadOnlyPage(pageNumber);
-						var numberOfPages = tx.DataPager.GetNumberOfOverflowPages(overflowPage.OverflowSize);
+						var overflowPage = _tx.GetReadOnlyPage(pageNumber);
+						var numberOfPages = _tx.DataPager.GetNumberOfOverflowPages(overflowPage.OverflowSize);
 						for (long j = 0; j < numberOfPages; ++j)
 							results.Add(overflowPage.PageNumber + j);
 					}
@@ -596,8 +594,8 @@ namespace Voron.Trees
 						results.Add(childTreeHeader->RootPageNumber);
 
 						// this is a multi value
-						var tree = OpenOrCreateMultiValueTree(tx, new Slice(node), node);
-						results.AddRange(tree.AllPages(tx));
+						var tree = OpenOrCreateMultiValueTree(_tx, new Slice(node), node);
+						results.AddRange(tree.AllPages());
 					}
 				}
 			}
@@ -608,7 +606,6 @@ namespace Voron.Trees
 		{
 			return Name + " " + State.EntriesCount;
 		}
-
 
 		private void CheckConcurrency(Slice key, ushort? expectedVersion, ushort nodeVersion, TreeActionType actionType)
 		{
@@ -623,24 +620,24 @@ namespace Voron.Trees
 				throw new ConcurrencyException(string.Format("Cannot {0} value '{5}' to key '{1}' to '{4}' tree. Version mismatch. Expected: {2}. Actual: {3}.", actionType.ToString().ToLowerInvariant(), key, expectedVersion.Value, nodeVersion, Name, value));
 		}
 
-		public enum TreeActionType
+		private enum TreeActionType
 		{
 			Add,
 			Delete
 		}
 
-		public Tree Clone()
+		internal Tree Clone(Transaction tx)
 		{
-			return new Tree(_cmp, _state.Clone()){ Name = Name };
+			return new Tree(tx, _cmp, _state.Clone()) { Name = Name };
 		}
 
-		private bool TryOverwriteOverflowPages(Transaction tx, TreeMutableState treeState, NodeHeader* updatedNode,
+		private bool TryOverwriteOverflowPages(TreeMutableState treeState, NodeHeader* updatedNode,
 													  Slice key, int len, ushort? version, out byte* pos)
 		{
 			if (updatedNode->Flags == NodeFlags.PageRef &&
-				tx.Id <= tx.Environment.OldestTransaction) // ensure MVCC - do not overwrite if there is some older active transaction that might read those overflows
+				_tx.Id <= _tx.Environment.OldestTransaction) // ensure MVCC - do not overwrite if there is some older active transaction that might read those overflows
 			{
-				var overflowPage = tx.GetReadOnlyPage(updatedNode->PageNumber);
+				var overflowPage = _tx.GetReadOnlyPage(updatedNode->PageNumber);
 
 				if (len <= overflowPage.OverflowSize)
 				{
@@ -650,15 +647,15 @@ namespace Voron.Trees
 						updatedNode->Version = 0;
 					updatedNode->Version++;
 
-					var availableOverflows = tx.DataPager.GetNumberOfOverflowPages(overflowPage.OverflowSize);
+					var availableOverflows = _tx.DataPager.GetNumberOfOverflowPages(overflowPage.OverflowSize);
 
-					var requestedOverflows = tx.DataPager.GetNumberOfOverflowPages(len);
+					var requestedOverflows = _tx.DataPager.GetNumberOfOverflowPages(len);
 
 					var overflowsToFree = availableOverflows - requestedOverflows;
 
 					for (int i = 0; i < overflowsToFree; i++)
 					{
-						tx.FreePage(overflowPage.PageNumber + requestedOverflows + i);
+						_tx.FreePage(overflowPage.PageNumber + requestedOverflows + i);
 					}
 
 					treeState.OverflowPages -= overflowsToFree;

--- a/Voron/Trees/Tree.cs
+++ b/Voron/Trees/Tree.cs
@@ -3,18 +3,15 @@ using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using Voron.Debugging;
+using Voron.Exceptions;
 using Voron.Impl;
 using Voron.Impl.FileHeaders;
 using Voron.Impl.Paging;
-using Voron.Util;
 
 namespace Voron.Trees
 {
-	using Exceptions;
-
-	public unsafe class Tree
+	public unsafe partial class Tree
 	{
 		private TreeMutableState _state = new TreeMutableState();
 
@@ -80,109 +77,64 @@ namespace Voron.Trees
 		    if (value.Length > int.MaxValue)
 		        throw new ArgumentException("Cannot add a value that is over 2GB in size", "value");
 
-		    State.IsModified = true;
-
-		    var pos = DirectAdd(tx, key, (int) value.Length, version: version);
+			State.IsModified = true;
+			var pos = DirectAdd(tx, key, (int)value.Length, version: version);
 		    
-		    var temporaryPage = tx.Environment.TemporaryPage;
-		    var tempPageBuffer = temporaryPage.TempPageBuffer;
-		    var tempPagePointer = temporaryPage.TempPagePointer;
-            while (true)
-		    {
-		        var read = value.Read(tempPageBuffer, 0, AbstractPager.PageSize);
-		        if (read == 0)
-		            break;
-		        NativeMethods.memcpy(pos , tempPagePointer, read);
-                pos += read;
-		    }
+		    CopyStreamToPointer(tx, value, pos);
 		}
 
-	    public void MultiDelete(Transaction tx, Slice key, Slice value, ushort? version = null)
-	    {
-		    State.IsModified = true;
-			Lazy<Cursor> lazy;
-		    var page = FindPageFor(tx, key, out lazy);
-		    if (page == null || page.LastMatch != 0)
-		    {
-			    return; //nothing to delete - key not found
-		    }
+		public long Increment(Transaction tx, Slice key, long delta, ushort? version = null)
+		{
+			long currentValue = 0;
 
-			page = tx.ModifyPage(page.PageNumber, page);
+			var read = Read(tx, key);
+			if (read != null)
+				currentValue = read.Reader.ReadLittleEndianInt64();
 
-		    var item = page.GetNode(page.LastSearchPosition);
+			var value = currentValue + delta;
+			Add(tx, key, BitConverter.GetBytes(value), version);
 
-		    if (item->Flags == NodeFlags.MultiValuePageRef) //multi-value tree exists
-		    {
-			    var tree = OpenOrCreateMultiValueTree(tx, key, item);
+			return value;
+		}
 
-			    tree.Delete(tx, value, version);
-
-			    if (tree.State.EntriesCount > 1)
-				    return;
-			    // convert back to simple key/val
-			    var iterator = tree.Iterate(tx);
-			    if (!iterator.Seek(Slice.BeforeAllKeys))
-				    throw new InvalidDataException(
-					    "MultiDelete() failed : sub-tree is empty where it should not be, this is probably a Voron bug.");
-
-			    var dataToSave = iterator.CurrentKey;
-
-			    var ptr = DirectAdd(tx, key, dataToSave.Size);
-			    dataToSave.CopyTo(ptr);
-
-			    tx.TryRemoveMultiValueTree(this, key);
-			    tx.FreePage(tree.State.RootPageNumber);
-		    }
-		    else //the regular key->value pattern
-		    {
-			    Delete(tx, key, version);
-		    }
-	    }
-
-		public void MultiAdd(Transaction tx, Slice key, Slice value, ushort? version = null)
+		public void Add(Transaction tx, Slice key, byte[] value, ushort? version = null)
 		{
 			if (value == null) throw new ArgumentNullException("value");
-			if (value.Size > tx.DataPager.MaxNodeSize)
-				throw new ArgumentException(
-					"Cannot add a value to child tree that is over " + tx.DataPager.MaxNodeSize + " bytes in size", "value");
-			if (value.Size == 0)
-				throw new ArgumentException("Cannot add empty value to child tree");
 
 			State.IsModified = true;
-			Lazy<Cursor> lazy;
-			var page = FindPageFor(tx, key, out lazy);
+			var pos = DirectAdd(tx, key, value.Length, version: version);
 
-			if (page == null || page.LastMatch != 0)
+			fixed (byte* src = value)
 			{
-				var ptr = DirectAdd(tx, key, value.Size, version: version);
-				value.CopyTo(ptr);
-				return;
+				NativeMethods.memcpy(pos, src, value.Length);
 			}
+		}
 
-			page = tx.ModifyPage(page.PageNumber, page);
+		public void Add(Transaction tx, Slice key, Slice value, ushort? version = null)
+		{
+			if (value == null) throw new ArgumentNullException("value");
 
-			var item = page.GetNode(page.LastSearchPosition);
+			State.IsModified = true;
+			var pos = DirectAdd(tx, key, value.Size, version: version);
 
-			CheckConcurrency(key, version, item->Version, TreeActionType.Add);
-			var existingValue = new Slice(DirectRead(tx, key), (ushort) item->DataSize);
-			if (existingValue.Compare(value, _cmp) == 0)
-				return; //nothing to do, the exact value is already there				
+			value.CopyTo(pos);
+		}
 
-			if (item->Flags == NodeFlags.MultiValuePageRef)
+		private static void CopyStreamToPointer(Transaction tx, Stream value, byte* pos)
+		{
+			TemporaryPage tmp;
+			using (tx.Environment.GetTemporaryPage(tx, out tmp))
 			{
-				var tree = OpenOrCreateMultiValueTree(tx, key, item);
-				tree.DirectAdd(tx, value, 0);
-			}
-			else // need to turn to tree
-			{
-				var tree = Create(tx, _cmp, TreeFlags.MultiValue);
-				var current = NodeHeader.GetData(tx, item);
-				tree.DirectAdd(tx, current, 0);
-				tree.DirectAdd(tx, value, 0);
-				tx.AddMultiValueTree(this, key, tree);
-
-				// we need to record that we switched to tree mode here, so the next call wouldn't also try to create the tree again
-				DirectAdd(tx, key, sizeof (TreeRootHeader), NodeFlags.MultiValuePageRef);
+				var tempPageBuffer = tmp.TempPageBuffer;
+				var tempPagePointer = tmp.TempPagePointer;
+				while (true)
+				{
+					var read = value.Read(tempPageBuffer, 0, AbstractPager.PageSize);
+					if (read == 0)
+						break;
+					NativeMethods.memcpy(pos, tempPagePointer, read);
+					pos += read;
+				}
 			}
 		}
 
@@ -279,23 +231,6 @@ namespace Voron.Trees
 			return dataPos;
 		}
 
-		public bool SetAsMultiValueTreeRef(Transaction tx, Slice key)
-		{
-			Lazy<Cursor> lazy;
-			var foundPage = FindPageFor(tx, key, out lazy);
-			var page = tx.ModifyPage(foundPage.PageNumber, foundPage);
-
-			if (page.LastMatch != 0)
-				return false; // not there
-
-			var nodeHeader = page.GetNode(page.LastSearchPosition);
-			if (nodeHeader->Flags == NodeFlags.MultiValuePageRef)
-				return false;
-			if (nodeHeader->Flags != NodeFlags.Data)
-				throw new InvalidOperationException("Only data nodes can be set to MultiValuePageRef");
-			nodeHeader->Flags = NodeFlags.MultiValuePageRef;
-			return true;
-		}
 
 		private long WriteToOverflowPages(Transaction tx, TreeMutableState txInfo, int overflowSize, out byte* dataPos)
 		{
@@ -375,8 +310,7 @@ namespace Voron.Trees
 
 	    private Page SearchForPage(Transaction tx, Slice key, ref Lazy<Cursor> cursor)
 	    {
-	        Page p;
-	        p = tx.GetReadOnlyPage(State.RootPageNumber);
+	        var p = tx.GetReadOnlyPage(State.RootPageNumber);
 	        var c = new Cursor();
 	        c.Push(p);
 
@@ -600,33 +534,6 @@ namespace Voron.Trees
 			return node->Version;
 		}
 
-		public IIterator MultiRead(Transaction tx, Slice key)
-		{
-			Lazy<Cursor> lazy;
-			var page = FindPageFor(tx, key, out lazy);
-
-			if (page == null || page.LastMatch != 0)
-			{
-				return new EmptyIterator();
-			}
-
-			var item = page.Search(key, _cmp);
-
-			var fetchedNodeKey = new Slice(item);
-			if (fetchedNodeKey.Compare(key, _cmp) != 0)
-			{
-				throw new InvalidDataException("Was unable to retrieve the correct node. Data corruption possible");
-			}
-
-			if (item->Flags == NodeFlags.MultiValuePageRef)
-			{
-				var tree = OpenOrCreateMultiValueTree(tx, key, item);
-
-				return tree.Iterate(tx);
-			}
-
-			return new SingleEntryIterator(_cmp, item, tx);
-		}
 
 		internal byte* DirectRead(Transaction tx, Slice key)
 		{
@@ -702,30 +609,19 @@ namespace Voron.Trees
 			return Name + " " + State.EntriesCount;
 		}
 
-		internal Tree OpenOrCreateMultiValueTree(Transaction tx, Slice key, NodeHeader* item)
-		{
-			Tree tree;
-			if (tx.TryGetMultiValueTree(this, key, out tree))
-				return tree;
 
-		    var childTreeHeader =
-		        (TreeRootHeader*) ((byte*) item + item->KeySize + Constants.NodeHeaderSize);
-			Debug.Assert(childTreeHeader->RootPageNumber < tx.State.NextPageNumber);
-            tree = childTreeHeader != null ?
-				Open(tx, _cmp, childTreeHeader) :
-				Create(tx, _cmp);
-
-			tx.AddMultiValueTree(this, key, tree);
-			return tree;
-		}
-
-		private static void CheckConcurrency(Slice key, ushort? expectedVersion, ushort nodeVersion, TreeActionType actionType)
+		private void CheckConcurrency(Slice key, ushort? expectedVersion, ushort nodeVersion, TreeActionType actionType)
 		{
 			if (expectedVersion.HasValue && nodeVersion != expectedVersion.Value)
-				throw new ConcurrencyException(string.Format("Cannot {0} '{1}'. Version mismatch. Expected: {2}. Actual: {3}.", actionType.ToString().ToLowerInvariant(), key, expectedVersion.Value, nodeVersion));
+				throw new ConcurrencyException(string.Format("Cannot {0} '{1}' to '{4}' tree. Version mismatch. Expected: {2}. Actual: {3}.", actionType.ToString().ToLowerInvariant(), key, expectedVersion.Value, nodeVersion, Name));
 		}
 
-		public bool IsMultiValueTree { get; set; }
+
+		private void CheckConcurrency(Slice key, Slice value, ushort? expectedVersion, ushort nodeVersion, TreeActionType actionType)
+		{
+			if (expectedVersion.HasValue && nodeVersion != expectedVersion.Value)
+				throw new ConcurrencyException(string.Format("Cannot {0} value '{5}' to key '{1}' to '{4}' tree. Version mismatch. Expected: {2}. Actual: {3}.", actionType.ToString().ToLowerInvariant(), key, expectedVersion.Value, nodeVersion, Name, value));
+		}
 
 		public enum TreeActionType
 		{
@@ -738,43 +634,7 @@ namespace Voron.Trees
 			return new Tree(_cmp, _state.Clone()){ Name = Name };
 		}
 
-		private static bool TryOverwriteDataOrMultiValuePageRefNode(NodeHeader* updatedNode, Slice key, int len,
-															NodeFlags requestedNodeType, ushort? version,
-															out byte* pos)
-		{
-			switch (requestedNodeType)
-			{
-				case NodeFlags.Data:
-				case NodeFlags.MultiValuePageRef:
-					{
-						if (updatedNode->DataSize == len &&
-							(updatedNode->Flags == NodeFlags.Data || updatedNode->Flags == NodeFlags.MultiValuePageRef))
-						{
-							CheckConcurrency(key, version, updatedNode->Version, TreeActionType.Add);
-
-							if (updatedNode->Version == ushort.MaxValue)
-								updatedNode->Version = 0;
-							updatedNode->Version++;
-
-							updatedNode->Flags = requestedNodeType;
-
-							{
-								pos = (byte*)updatedNode + Constants.NodeHeaderSize + key.Size;
-								return true;
-							}
-						}
-						break;
-					}
-				case NodeFlags.PageRef:
-					throw new InvalidOperationException("We never add PageRef explicitly");
-				default:
-					throw new ArgumentOutOfRangeException();
-			}
-			pos = null;
-			return false;
-		}
-
-		private static bool TryOverwriteOverflowPages(Transaction tx, TreeMutableState treeState, NodeHeader* updatedNode,
+		private bool TryOverwriteOverflowPages(Transaction tx, TreeMutableState treeState, NodeHeader* updatedNode,
 													  Slice key, int len, ushort? version, out byte* pos)
 		{
 			if (updatedNode->Flags == NodeFlags.PageRef &&

--- a/Voron/Trees/TreeIterator.cs
+++ b/Voron/Trees/TreeIterator.cs
@@ -30,7 +30,7 @@ namespace Voron.Trees
 		public bool Seek(Slice key)
 		{
 			Lazy<Cursor> lazy;
-			_currentPage = _tree.FindPageFor(_tx, key, out lazy);
+			_currentPage = _tree.FindPageFor(key, out lazy);
 			_cursor = lazy.Value;
 			_cursor.Pop();
 			var node = _currentPage.Search(key, _cmp);
@@ -62,7 +62,7 @@ namespace Voron.Trees
 		/// </summary>
 		public bool DeleteCurrentAndMoveNext()
 		{
-			_tree.Delete(_tx, CurrentKey);
+			_tree.Delete(CurrentKey);
 			return MovePrev() && MoveNext();
 		}
 

--- a/Voron/Trees/TreeIterator.cs
+++ b/Voron/Trees/TreeIterator.cs
@@ -22,23 +22,9 @@ namespace Voron.Trees
 			_cmp = cmp;
 		}
 
-
 		public int GetCurrentDataSize()
 		{
 			return NodeHeader.GetDataSize(_tx, Current);
-		}
-
-		public IIterator CreateMutliValueIterator()
-		{
-			var item = Current;
-			if (item->Flags == NodeFlags.MultiValuePageRef)
-			{
-				var tree = _tree.OpenOrCreateMultiValueTree(_tx, _currentKey, item);
-
-				return tree.Iterate(_tx);
-			}
-
-			return new SingleEntryIterator(_cmp, item, _tx);
 		}
 
 		public bool Seek(Slice key)
@@ -47,14 +33,6 @@ namespace Voron.Trees
 			_currentPage = _tree.FindPageFor(_tx, key, out lazy);
 			_cursor = lazy.Value;
 			_cursor.Pop();
-
-			//if required prefix is set and need to seek to beginning/end
-			//--> skip to beginning of relevant keys
-			if (RequiredPrefix != null &&
-			    !RequiredPrefix.Equals(Slice.Empty) &&
-			   (key.Equals(Slice.BeforeAllKeys) || key.Equals(Slice.AfterAllKeys)))
-				key = RequiredPrefix;
-
 			var node = _currentPage.Search(key, _cmp);
 			if (node == null)
 			{
@@ -68,18 +46,36 @@ namespace Voron.Trees
 		{
 			get
 			{
-				if (_currentPage == null || _currentPage.LastSearchPosition >= _currentPage.NumberOfEntries)
+				if (_currentPage == null)
 					throw new InvalidOperationException("No current page was set");
+
+				if (_currentPage.LastSearchPosition >= _currentPage.NumberOfEntries)
+					throw new InvalidOperationException(string.Format("Current page is invalid. Search position ({0}) exceeds number of entries ({1}). Page: {2}.", _currentPage.LastSearchPosition, _currentPage.NumberOfEntries, _currentPage));
+					
 				return _currentKey;
 			}
+		}
+
+		/// <summary>
+		/// Deletes the current key/value pair and returns true if there is 
+		/// another key after it
+		/// </summary>
+		public bool DeleteCurrentAndMoveNext()
+		{
+			_tree.Delete(_tx, CurrentKey);
+			return MovePrev() && MoveNext();
 		}
 
 		public NodeHeader* Current
 		{
 			get
 			{
-				if (_currentPage == null || _currentPage.LastSearchPosition >= _currentPage.NumberOfEntries)
+				if (_currentPage == null)
 					throw new InvalidOperationException("No current page was set");
+
+				if (_currentPage.LastSearchPosition >= _currentPage.NumberOfEntries)
+					throw new InvalidOperationException(string.Format("Current page is invalid. Search position ({0}) exceeds number of entries ({1}). Page: {2}.", _currentPage.LastSearchPosition, _currentPage.NumberOfEntries, _currentPage));
+					
 				return _currentPage.GetNode(_currentPage.LastSearchPosition);
 			}
 		}
@@ -163,17 +159,6 @@ namespace Voron.Trees
 			return NodeHeader.Reader(_tx, Current);
 		}
 
-		public IEnumerable<string> DumpValues()
-		{
-			if(Seek(Slice.BeforeAllKeys) == false)
-				yield break;
-
-			do
-			{
-				yield return CurrentKey.ToString();
-			} while (MoveNext());
-		}
-
 		public void Dispose()
 		{
 		}
@@ -190,6 +175,17 @@ namespace Voron.Trees
 
 	public static class IteratorExtensions
 	{
+		public static IEnumerable<string> DumpValues(this IIterator self)
+		{
+			if (self.Seek(Slice.BeforeAllKeys) == false)
+				yield break;
+
+			do
+			{
+				yield return self.CurrentKey.ToString();
+			} while (self.MoveNext());
+		}
+
 		public unsafe static bool ValidateCurrentKey(this IIterator self, NodeHeader* node, SliceComparer cmp)
 		{
 			if (self.RequiredPrefix != null)

--- a/Voron/Trees/TreeIterator.cs
+++ b/Voron/Trees/TreeIterator.cs
@@ -47,6 +47,14 @@ namespace Voron.Trees
 			_currentPage = _tree.FindPageFor(_tx, key, out lazy);
 			_cursor = lazy.Value;
 			_cursor.Pop();
+
+			//if required prefix is set and need to seek to beginning/end
+			//--> skip to beginning of relevant keys
+			if (RequiredPrefix != null &&
+			    !RequiredPrefix.Equals(Slice.Empty) &&
+			   (key.Equals(Slice.BeforeAllKeys) || key.Equals(Slice.AfterAllKeys)))
+				key = RequiredPrefix;
+
 			var node = _currentPage.Search(key, _cmp);
 			if (node == null)
 			{

--- a/Voron/Trees/TreeRebalancer.cs
+++ b/Voron/Trees/TreeRebalancer.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using Voron.Debugging;
 using Voron.Impl;
+using Voron.Impl.Paging;
 
 namespace Voron.Trees
 {
@@ -30,14 +31,13 @@ namespace Voron.Trees
 
             if (page.NumberOfEntries == 0) // empty page, just delete it and fixup parent
             {
-				// need to delete the implicit left page, shift right 
-                if (parentPage.LastSearchPosition == 0 && parentPage.NumberOfEntries > 2)
-                {
+				// need to change the implicit left page
+				if (parentPage.LastSearchPosition == 0 && parentPage.NumberOfEntries > 2)
+				{
 					var newImplicit = parentPage.GetNode(1)->PageNumber;
-                    parentPage.RemoveNode(0);
-                    parentPage.RemoveNode(0);
-                    parentPage.AddPageRefNode(0, Slice.Empty, newImplicit);
-                }
+					parentPage.RemoveNode(0);
+					parentPage.ChangeImplicitRefPageNode(newImplicit);
+				}
                 else // will be set to rights by the next rebalance call
                 {
                     parentPage.RemoveNode(parentPage.LastSearchPositionOrLastEntry);
@@ -219,8 +219,8 @@ namespace Voron.Trees
                 var implicitLeftKey = GetActualKey(to, 0);
                 var leftPageNumber = to.GetNode(0)->PageNumber;
                 to.AddPageRefNode(1, implicitLeftKey, leftPageNumber);
-                to.AddPageRefNode(0, Slice.BeforeAllKeys, pageNum);
-                to.RemoveNode(1);
+
+				to.ChangeImplicitRefPageNode(pageNum); // setup the new implicit node
             }
             else
             {
@@ -229,12 +229,9 @@ namespace Voron.Trees
 
             if (from.LastSearchPositionOrLastEntry == 0)
             {
-                // cannot just remove the left node, need to adjust those
                 var rightPageNumber = from.GetNode(1)->PageNumber;
                 from.RemoveNode(0); // remove the original implicit node
-                from.RemoveNode(0); // remove the next node that we now turned into implicit
-                from.EnsureHasSpaceFor(_tx, Slice.BeforeAllKeys, -1);
-                from.AddPageRefNode(0, Slice.BeforeAllKeys, rightPageNumber);
+                from.ChangeImplicitRefPageNode(rightPageNumber); // setup the new implicit node
                 Debug.Assert(from.NumberOfEntries >= 2);
             }
             else

--- a/Voron/Util/PageTable.cs
+++ b/Voron/Util/PageTable.cs
@@ -107,13 +107,9 @@ namespace Voron.Util
 
 		public long MaxTransactionId()
 		{
-			var transactionIds = _values.Values.Select(x => x[x.Count - 1].Value)
-											   .Where(x => x != null)
-											   .ToList();
-			if(transactionIds.Any())
-				return transactionIds.Max(x => x.TransactionId);
-
-			return -1;
+			return _values.Values.Select(x => x[x.Count - 1].Value)
+				.Where(x => x != null)
+				.Max(x => x.TransactionId);
 		}
 
 		public List<KeyValuePair<long, JournalFile.PagePosition>> AllPagesOlderThan(long oldestActiveTransaction)
@@ -124,20 +120,7 @@ namespace Voron.Util
 				return val.Value.TransactionId < oldestActiveTransaction;
 			}).Select(x => new KeyValuePair<long, JournalFile.PagePosition>(x.Key, x.Value[x.Value.Count - 1].Value))
 				.ToList();
-		}
 
-		public void SetItemsNoTransaction(Dictionary<long, JournalFile.PagePosition> ptt)
-		{
-			foreach (var item in ptt)
-			{
-				var result = _values.TryAdd(item.Key, ImmutableAppendOnlyList<PageValue>.Empty.Append(new PageValue
-				{
-					Transaction = -1,
-					Value = item.Value
-				}));
-				if (result == false)
-					throw new InvalidOperationException("Duplicate item or calling SetItemsNoTransaction twice? " + item.Key);
-			}
 		}
 
 		public long GetLastSeenTransaction()

--- a/Voron/Util/TreeExtensions.cs
+++ b/Voron/Util/TreeExtensions.cs
@@ -18,10 +18,14 @@ namespace Voron
             if (treeName.Equals(Constants.FreeSpaceTreeName, StringComparison.InvariantCultureIgnoreCase))
                 return state.FreeSpaceRoot;
 
+
 		    Tree tree = tx.ReadTree(treeName);
 
 			if (tree != null)
 				return tree;
+
+			if (tx.Flags == TransactionFlags.ReadWrite)
+				return tx.Environment.CreateTree(tx, treeName);
 
 			throw new InvalidOperationException("No such tree: " + treeName);			
 		}

--- a/Voron/ValueReader.cs
+++ b/Voron/ValueReader.cs
@@ -2,122 +2,234 @@
 using System.IO;
 using System.Text;
 using Voron.Impl;
+using Voron.Util;
+using Voron.Util.Conversion;
 
 namespace Voron
 {
-    public unsafe class ValueReader
-    {
-        private readonly byte* _val;
-        private readonly byte[] _buffer;
-        private readonly int _len;
+	public unsafe struct ValueReader
+	{
+        [ThreadStatic]
+        private static byte[] tmpBuf;
+		
         private int _pos;
-        public int Length { get { return _len; } }
+		private readonly byte[] _buffer;
+		private readonly int _len;
+		private readonly byte* _val;
 
-        public void Reset()
-        {
-            _pos = 0;
-        }
+		public ValueReader(Stream stream)
+		{
+			long position = stream.Position;
+			_len = (int) (stream.Length - stream.Position);
+			_buffer = new byte[_len];
 
-        public ValueReader(Stream stream)
-        {
-            var position = stream.Position;
-            _len = (int)(stream.Length - stream.Position);
-            _buffer = new byte[_len];
+			int pos = 0;
+			while (true)
+			{
+				int read = stream.Read(_buffer, pos, _buffer.Length - pos);
+				if (read == 0)
+					break;
+				pos += read;
+			}
+			stream.Position = position;
 
-            int pos = 0;
-            while (true)
-            {
-                var read = stream.Read(_buffer, pos, _buffer.Length - pos);
-                if (read == 0)
-                    break;
-                pos += read;
-            }
-            stream.Position = position;
+		    _pos = 0;
+		    _val = null;
+		}
 
-        }
-
-	    public Stream AsStream()
+	    public ValueReader(byte[] array, int len)
 	    {
-		    if (_val == null)
-			    return new MemoryStream(_buffer, writable: false);
-		    return new UnmanagedMemoryStream(_val, _len, _len, FileAccess.Read);
+	        if (array == null) throw new ArgumentNullException("array");
+	        _buffer = array;
+	        _len = len;
+	        _pos = 0;
+	        _val = null;
 	    }
 
-        public ValueReader(byte* val, int len)
-        {
-            _val = val;
-            _len = len;
-        }
+		public ValueReader(byte* val, int len)
+		{
+			_val = val;
+			_len = len;
+			_pos = 0;
+		    _buffer = null;
+		}
 
-        public int Read(byte[] buffer, int offset, int count)
-        {
-            fixed (byte* b = buffer)
-                return Read(b + offset, count);
-        }
+		public int Length
+		{
+			get { return _len; }
+		}
 
-        public int Read(byte* buffer, int count)
-        {
-            count = Math.Min(count, _len - _pos);
+		public bool EndOfData
+		{
+			get { return _len == _pos; }
+		}
 
-            if (_val == null)
-            {
-                fixed (byte* b = _buffer)
-                    NativeMethods.memcpy(buffer, b + _pos, count);
-            }
-            else
-            {
-                NativeMethods.memcpy(buffer, _val + _pos, count);
-            }
-            _pos += count;
+		public void Reset()
+		{
+			_pos = 0;
+		}
 
-            return count;
-        }
+		public Stream AsStream()
+		{
+			if (_val == null)
+				return new MemoryStream(_buffer, false);
+			return new UnmanagedMemoryStream(_val, _len, _len, FileAccess.Read);
+		}
 
-        public int ReadInt32()
-        {
-            if (_len - _pos < sizeof(int))
-                throw new EndOfStreamException();
-            var buffer = new byte[sizeof(int)];
+		public int Read(byte[] buffer, int offset, int count)
+		{
+			fixed (byte* b = buffer)
+				return Read(b + offset, count);
+		}
 
-            Read(buffer, 0, sizeof (int));
+		public int Read(byte* buffer, int count)
+		{
+			count = Math.Min(count, _len - _pos);
 
-            return BitConverter.ToInt32(buffer, 0);
-        }
+			if (_val == null)
+			{
+				fixed (byte* b = _buffer)
+					NativeMethods.memcpy(buffer, b + _pos, count);
+			}
+			else
+			{
+				NativeMethods.memcpy(buffer, _val + _pos, count);
+			}
+			_pos += count;
 
-        public long ReadInt64()
-        {
-            if (_len - _pos < sizeof(long))
-                throw new EndOfStreamException();
-            var buffer = new byte[sizeof(long)];
+			return count;
+		}
 
-            Read(buffer, 0, sizeof(long));
+        public int ReadLittleEndianInt32()
+		{
+			if (_len - _pos < sizeof (int))
+				throw new EndOfStreamException();
+	        var buffer = EnsureTempBuffer(sizeof (int));
 
-            return BitConverter.ToInt64(buffer, 0);
-        }
+			Read(buffer, 0, sizeof (int));
 
-        public string ToStringValue()
-        {
-            return Encoding.UTF8.GetString(ReadBytes(_len - _pos));
-        }
+			return BitConverter.ToInt32(buffer, 0);
+		}
 
-        public byte[] ReadBytes(int length)
-        {
-            var size = Math.Min(length, _len - _pos);
-            var buffer = new byte[size];
-            Read(buffer, 0, size);
-            return buffer;
-        }
 
-        public void CopyTo(Stream stream)
-        {
-            var buffer = new byte[4096];
-            while (true)
-            {
-                var read = Read(buffer, 0, buffer.Length);
-                if (read == 0)
-                    return;
-                stream.Write(buffer, 0, read);
-            }
-        }
-    }
+		public long ReadLittleEndianInt64()
+		{
+			if (_len - _pos < sizeof (long))
+				throw new EndOfStreamException();
+			var buffer = EnsureTempBuffer(sizeof(long));
+
+			Read(buffer, 0, sizeof (long));
+
+			return BitConverter.ToInt64(buffer, 0);
+		}
+
+		public int ReadBigEndianInt32()
+		{
+			if (_len - _pos < sizeof(int))
+				throw new EndOfStreamException();
+			var buffer = EnsureTempBuffer(sizeof(int));
+
+			Read(buffer, 0, sizeof(int));
+
+			return EndianBitConverter.Big.ToInt32(buffer, 0);
+		}
+
+
+		public long ReadBigEndianInt64()
+		{
+			if (_len - _pos < sizeof(long))
+				throw new EndOfStreamException();
+			var buffer = EnsureTempBuffer(sizeof(long));
+
+			Read(buffer, 0, sizeof(long));
+
+			return EndianBitConverter.Big.ToInt64(buffer, 0);
+		}
+
+
+	    private byte[] EnsureTempBuffer(int size)
+	    {
+		    if (tmpBuf != null && tmpBuf.Length >= size)
+			    return tmpBuf;
+		    return tmpBuf = new byte[Utils.NearestPowerOfTwo(size)];
+	    }
+
+		public string ToStringValue()
+		{
+	        int length = _len - _pos;
+	        int used;
+	        return Encoding.UTF8.GetString(ReadBytes(length, out used), 0, used);
+		}
+
+		public override string ToString()
+		{
+			var old = _pos;
+			var stringValue = ToStringValue();
+			_pos = old;
+			return stringValue;
+		}
+
+	    public byte[] ReadBytes(int length, out int used)
+		{
+			int size = Math.Min(length, _len - _pos);
+	        var buffer = EnsureTempBuffer(length);
+			used = Read(buffer, 0, size);
+			return buffer;
+		}
+
+		public void CopyTo(Stream stream)
+		{
+			var buffer = new byte[4096];
+			while (true)
+			{
+				int read = Read(buffer, 0, buffer.Length);
+				if (read == 0)
+					return;
+				stream.Write(buffer, 0, read);
+			}
+		}
+
+		public int CompareTo(ValueReader other)
+		{
+			int r = CompareData(other, Math.Min(Length, other.Length));
+			if (r != 0)
+				return r;
+			return Length - other.Length;
+		}
+
+		private int CompareData(ValueReader other, int len)
+		{
+			if (_buffer != null)
+			{
+				fixed (byte* a = _buffer)
+				{
+					if (other._buffer != null)
+					{
+						fixed (byte* b = other._buffer)
+						{
+							return NativeMethods.memcmp(a, b, len);
+						}
+					}
+					return NativeMethods.memcmp(a, other._val, len);
+				}
+			}
+			if (other._buffer != null)
+			{
+				fixed (byte* b = other._buffer)
+				{
+					return NativeMethods.memcmp(_val, b, len);
+				}
+			}
+			return NativeMethods.memcmp(_val, other._val, len);
+		}
+
+		public Slice AsSlice()
+		{
+			if (_len >= ushort.MaxValue)
+				throw new InvalidOperationException("Cannot convert to slice, len is too big: " + _len);
+			if (_buffer != null)
+				return new Slice(_buffer, (ushort) _len);
+			return new Slice(_val, (ushort) _len);
+		}
+	}
 }

--- a/Voron/ValueReader.cs
+++ b/Voron/ValueReader.cs
@@ -17,6 +17,8 @@ namespace Voron
 		private readonly int _len;
 		private readonly byte* _val;
 
+        public byte* Base { get { return _val; } }
+
 		public ValueReader(Stream stream)
 		{
 			long position = stream.Position;

--- a/Voron/Voron.csproj
+++ b/Voron/Voron.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Voron</RootNamespace>
     <AssemblyName>Voron</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -62,14 +62,15 @@
     <Compile Include="Exceptions\QuotaException.cs" />
     <Compile Include="Impl\Backup\FullBackup.cs" />
     <Compile Include="Impl\Backup\IncrementalBackupInfo.cs" />
+    <Compile Include="Impl\Backup\VoronBackupUtil.cs" />
     <Compile Include="Impl\Constants.cs" />
     <Compile Include="Impl\Extensions\ConcurrentQueueExtensions.cs" />
     <Compile Include="Impl\Backup\IncrementalBackup.cs" />
-    <Compile Include="Impl\Extensions\MiscExtensions.cs" />
-    <Compile Include="Impl\Journal\ShippedTransactionsReader.cs" />
-    <Compile Include="Impl\Journal\TransactionToShip.cs" />
     <Compile Include="Impl\MemoryMapNativeMethods.cs" />
     <Compile Include="Impl\Paging\Win32PageFileBackedMemoryMappedPager.cs" />
+    <Compile Include="SliceWriter.cs" />
+    <Compile Include="Trees\PageIterator.cs" />
+    <Compile Include="Trees\Tree.MultiTree.cs" />
     <Compile Include="Util\ConcurrentSet.cs" />
     <Compile Include="Util\EndOfDiskSpaceEvent.cs" />
     <Compile Include="Util\GenericUtil.cs" />
@@ -115,7 +116,6 @@
     <Compile Include="Impl\NativeMethods.cs" />
     <Compile Include="Trees\EmptyIterator.cs" />
     <Compile Include="Trees\IIterator.cs" />
-    <Compile Include="Trees\SingleEntryIterator.cs" />
     <Compile Include="Trees\TreeIterator.cs" />
     <Compile Include="Trees\NodeFlags.cs" />
     <Compile Include="Trees\NodeHeader.cs" />


### PR DESCRIPTION
- the tweak on iterator's seek is this commit -> https://github.com/myarichuk/raven.voron/commit/01662db819d7292903ccdfe095551c4d0c9c2fd7
  what I think that if RequiredPrefix is set - it is kind of "filter" that lets you iterate on only relevant keys, and this tweak makes seeks to begin and end more intuitive
  Thats the main reason for this PR
- some commits seems to have accumulated on my branch of Voron, and I think it would be good to check if no code that should be in Voron  was left out by accident
